### PR TITLE
Change French timplace names to English.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Python datetimes made easy.
     delta.hours
     23
     delta.for_humans(locale='fr')
-    '6 jours 23 heures 58 minutes'
+    '6 days 23 hours 58 minutes'
 
 Resources
 =========


### PR DESCRIPTION
It makes it easier to read for people that speak English.
Just a suggestion. Doesn't have to be merged.