### PR TITLE
Allow pendulum comparison to None.

### DIFF
--- a/pendulum/pendulum.py
+++ b/pendulum/pendulum.py
@@ -2139,6 +2139,9 @@ class Pendulum(datetime.datetime, TranslatableMixin):
 
         :rtype: datetime or Pendulum
         """
+        if value is None:
+            return None
+
         if isinstance(value, Pendulum):
             return value._datetime if not pendulum else value
 

--- a/tests/pendulum_tests/test_comparison.py
+++ b/tests/pendulum_tests/test_comparison.py
@@ -65,6 +65,11 @@ class ComparisonTest(AbstractTestCase):
         self.assertNotEqual(d1, d2)
         self.assertEqual(d1, d3)
 
+    def test_not_equal_to_none(self):
+        d1 = Pendulum(2000, 1, 1, 1, 2, 3)
+
+        self.assertNotEqual(d1, None)
+
     def test_greater_than_true(self):
         d1 = Pendulum(2000, 1, 1)
         d2 = Pendulum(1999, 12, 31)


### PR DESCRIPTION
A comparison between a `Pendulum` object and `None` raises the following error:

``` python
>>> import pendulum
>>> pendulum.now() == None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vagrant/.pyenv/versions/server/lib/python2.7/site-packages/pendulum/pendulum.py", line 1129, in __eq__
    return self._datetime == self._get_datetime(other)
  File "/home/vagrant/.pyenv/versions/server/lib/python2.7/site-packages/pendulum/pendulum.py", line 2159, in _get_datetime
    raise ValueError('Invalid datetime "{}"'.format(value))
ValueError: Invalid datetime "None"
```

To fix, I modified `_get_datetime` to return `None` if `value` is `None`.