### PR TITLE
Resolve an AttributeError when calling between

### DIFF
--- a/pendulum/pendulum.py
+++ b/pendulum/pendulum.py
@@ -1166,9 +1166,6 @@ class Pendulum(datetime.datetime, TranslatableMixin):
 
         :rtype: bool
         """
-        dt1 = self._get_datetime(dt1)
-        dt2 = self._get_datetime(dt2)
-
         if dt1 > dt2:
             dt1, dt2 = dt2, dt1
 

--- a/tests/pendulum_tests/test_comparison.py
+++ b/tests/pendulum_tests/test_comparison.py
@@ -2,6 +2,7 @@
 
 import pytz
 from datetime import datetime
+from time import sleep
 from pendulum import Pendulum
 
 from .. import AbstractTestCase
@@ -293,6 +294,15 @@ class ComparisonTest(AbstractTestCase):
 
         self.assertFalse(d1.between(d3, d2, False))
         self.assertFalse(d1.between(d5, d4, False))
+
+    def test_between_issue_39(self):
+        old = Pendulum.instance(datetime.utcnow())
+        sleep(0.2)
+        mid = Pendulum.now('UTC')
+        sleep(0.2)
+        new = Pendulum.instance(datetime.utcnow())
+
+        self.assertTrue(mid.between(old, new))
 
     def test_min_is_fluid(self):
         d = Pendulum.now()


### PR DESCRIPTION
This seemed to be caused by passing two Pendulum objects created by `pendulum.instance(... datetime ...)` to `pendulum.now().between(...)`. Removing this explicit conversion prevents a double conversion caused by the `__gt__` method, which raised an AttributeError (because, of course, native DT objects, already extracted, will not contain a `_datetime` attribute).

This bug was at least found in pendulum 0.5.4 on python 2.7, my local dev environment for my current project.