### PR TITLE
Fixes non-support of PEP-3151 in Python v3 to v3.2.

### DIFF
--- a/pendulum/_compat.py
+++ b/pendulum/_compat.py
@@ -8,19 +8,18 @@ PY33 = sys.version_info >= (3, 3)
 
 
 if PY2:
-
     long = long
     unicode = unicode
     basestring = basestring
-    FileNotFoundError = IOError
-
 else:
-
-    FileNotFoundError = FileNotFoundError
     long = int
     unicode = str
     basestring = str
 
+if PY33:
+    FileNotFoundError = FileNotFoundError
+else:
+    FileNotFoundError = IOError # cf PEP-3151 
 
 def decode(string, encodings=None):
     if not PY2 and not isinstance(string, bytes):


### PR DESCRIPTION
The `IOError` refactoring has been introduced by PEP-3151 which has been implemented in Python 3.3+. This patch fixes the bug by having `FileNotFoundError` assigned as `IOError` on ≤3.2 pythons.

* fixes issue #41