### PR TITLE
Add support for instancing tz-aware datetime objects

### DIFF
--- a/pendulum/pendulum.py
+++ b/pendulum/pendulum.py
@@ -199,6 +199,23 @@ class Pendulum(datetime.datetime, TranslatableMixin):
         """
         tz = dt.tzinfo or tz
 
+        if dt.tzinfo:
+            offset = None
+
+            if hasattr(dt.tzinfo, '_utcoffset'):
+                offset = dt.tzinfo._utcoffset
+            elif hasattr(dt.tzinfo, '_offset'):
+                offset = dt.tzinfo._offset
+
+            if offset is not None:
+                try:
+                    offset_seconds = offset.total_seconds()
+                except AttributeError:
+                    offset_seconds = float((offset.microseconds +
+                        (offset.seconds + offset.days * 24 * 3600) * 10**6)) / 10**6
+
+                tz = FixedTimezone(offset_seconds)
+
         return cls(
             dt.year, dt.month, dt.day,
             dt.hour, dt.minute, dt.second, dt.microsecond,

--- a/tests/pendulum_tests/test_construct.py
+++ b/tests/pendulum_tests/test_construct.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import pytz
 from datetime import datetime
 from pendulum import Pendulum
 from pendulum.tz import timezone
@@ -114,6 +115,21 @@ class ConstructTest(AbstractTestCase):
     def test_instance_timezone_aware_datetime(self):
         now = Pendulum.instance(datetime.now(TimezoneInfo.create(timezone('Europe/Paris'), 7200, True, 'EST')))
         self.assertEqual('Europe/Paris', now.timezone_name)
+
+    def test_instance_foreign_tz_aware_datetime(self):
+        for tz in ('America/Chicago', 'UTC', 'Australia/Melbourne'):
+            from_naive = Pendulum.instance(
+                datetime(year=2016, month=1, day=1, hour=0, minute=0, second=0),
+                tz
+            )
+
+            aware_pytz = pytz.timezone(tz).localize(
+                datetime(year=2016, month=1, day=1, hour=0, minute=0, second=0)
+            )
+
+            from_aware_pytz = Pendulum.instance(aware_pytz)
+
+            self.assertEqual(from_aware_pytz.isoformat(), from_naive.isoformat())
 
     def test_now(self):
         now = Pendulum.now()


### PR DESCRIPTION
This is confirmed (by included unit tests) working with pytz'd datetimes, and also worked locally with some `psycopg2.tz.FixedOffsetTimezone` instances PostgreSQL gave us (which are obviously far out of scope of pendulum unit tests, and thus aren't included).

This makes some general assumptions about the type of stuff coming into the function:

* Pendulum TZ objects will never include `_utcoffset` or `_offset` properties. Seems legit - the Pendulum TZ classes currently don't expose anything of the sort.

* The incoming object *does* include one of those two properties, which contains a `datetime.timedelta` object (or something like it). We'll prefer to use `datetime.timedelta#total_seconds()` to create a Pendulum `FixedTimezone` if it's available (2.7+), but will fall back to calculating it ourselves if it's not. Shouldn't be an issue given Pendulum doesn't advertise 2.6 support, so feel free to remove that safety code if you'd like. It was borrowed from [here](https://stackoverflow.com/questions/3318348/how-can-i-extend-pythons-datetime-datetime-with-my-own-methods/14214646#14214646) anyway.