### PR TITLE
Add common intervals to the Interval class

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1504,6 +1504,20 @@ It also has a handy ``in_words()``, which determines the interval representation
     it.in_words(locale='de')
     '168 Wochen 1 Tag 2 Stunden 1 Minute 24 Sekunden'
 
+Some commonly used intervals are also provided as class variables of the ``Interval`` class.
+
+.. code-block:: python
+
+    from pendulum import interval
+
+    it = interval(days=10, hours=5)
+
+    it2 = it + 2 * interval.day - 3 * interval.hour
+
+    it2.days
+    12
+    it2.hours
+    2
 
 Period
 ======

--- a/pendulum/interval.py
+++ b/pendulum/interval.py
@@ -284,6 +284,14 @@ Interval.max = Interval(days=999999999, hours=23,
                         microseconds=999999)
 Interval.resolution = Interval(microseconds=1)
 
+Interval.day = Interval(days=1)
+Interval.second = Interval(seconds=1)
+Interval.microsecond = Interval(microseconds=1)
+Interval.millisecond = Interval(milliseconds=1)
+Interval.minute = Interval(minutes=1)
+Interval.hour = Interval(hours=1)
+Interval.week = Interval(weeks=1)
+
 
 class AbsoluteInterval(Interval):
     """


### PR DESCRIPTION
This is similar to the proposal in #17. Instead of having common intervals inside the ``pendulum`` module root, they are added as class variables to the ``Interval`` class.