### PR TITLE
Fix utcoffset

### DIFF
--- a/pendulum/tz/timezone.py
+++ b/pendulum/tz/timezone.py
@@ -280,7 +280,7 @@ class Timezone(tzinfo):
         elif dt.tzinfo.tz is not self:
             dt = self.convert(dt)
 
-            return dt.adjusted_offset
+            return dt.tzinfo.adjusted_offset
 
         return dt.utcoffset(dt)
 

--- a/tests/tz_tests/test_timezone.py
+++ b/tests/tz_tests/test_timezone.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pendulum
-from datetime import datetime
+from datetime import datetime, timedelta
 from pendulum import timezone
 from pendulum.tz.exceptions import NonExistingTime, AmbiguousTime
 
@@ -146,3 +146,8 @@ class TimezoneTest(AbstractTestCase):
         self.assertEqual('Europe/Paris', dt.timezone_name)
         self.assertEqual(3600, dt.offset)
         self.assertFalse(dt.is_dst)
+
+    def test_utcoffset(self):
+        tz = pendulum.timezone('Europe/Paris')
+        utcoffset = tz.utcoffset(pendulum.utcoffset())
+        self.assertEqual(utcoffset, timedelta(0, 3600))

--- a/tests/tz_tests/test_timezone.py
+++ b/tests/tz_tests/test_timezone.py
@@ -149,5 +149,5 @@ class TimezoneTest(AbstractTestCase):
 
     def test_utcoffset(self):
         tz = pendulum.timezone('Europe/Paris')
-        utcoffset = tz.utcoffset(pendulum.utcoffset())
+        utcoffset = tz.utcoffset(pendulum.utcnow())
         self.assertEqual(utcoffset, timedelta(0, 3600))


### PR DESCRIPTION
Usage of tzinfo must have been forgotten when coding this method. It works properly now.

$> python
```
>>> import pendulum
>>> tz = pendulum('Europe/Paris')
>>> tz.utcoffset(pendulum.utcnow())
datetime.timedelta(0, 3600)
```