### PR TITLE
Fix issue with microsecond rounding in C extensions.

### DIFF
--- a/pendulum/_extensions/_helpers.c
+++ b/pendulum/_extensions/_helpers.c
@@ -3,6 +3,7 @@
 #include <Python.h>
 #include <stdint.h>
 #include <datetime.h>
+#include <math.h>
 
 #ifndef PyVarObject_HEAD_INIT
 #define PyVarObject_HEAD_INIT(type, size) PyObject_HEAD_INIT(type) size,
@@ -113,7 +114,7 @@ PyObject* local_time(PyObject *self, PyObject *args) {
     }
 
     year = EPOCH_YEAR;
-    microsecond = (int64_t) (unix_time * 1000000) % 1000000;
+    microsecond = (int64_t) round(fmod(unix_time, 1) * 1000000);
     if (microsecond < 0) {
         microsecond += 1000000;
     }

--- a/tests/pendulum_tests/test_construct.py
+++ b/tests/pendulum_tests/test_construct.py
@@ -179,3 +179,7 @@ class ConstructTest(AbstractTestCase):
         dt = Pendulum.create(tz='Etc/UTC')
 
         self.assertEqual('Etc/UTC', dt.timezone_name)
+
+    def test_create_maintains_microseconds(self):
+        d = Pendulum.create(2016, 11, 12, 2, 9, 39, 594000, 'America/Panama')
+        self.assertPendulum(d, 2016, 11, 12, 2, 9, 39, 594000)


### PR DESCRIPTION
As described in https://github.com/sdispater/pendulum/issues/74 there is
a difference in the behavior of the C extension and Python
implementation in terms of handling microseconds.

The problem is that a microsecond value passed in may have an off-by-one
difference for certain values due to how floating point numbers are
handled, unless rounding is performed.

```python
  >>> import pendulum
  >>> pendulum.create(2016, 11, 12, 2, 9, 39, 594000, 'America/Panama').microsecond
  593999
```

This commit adds the same rounding behavior to the C extension as used
in the Python version.