### PR TITLE
New Parser Behavior for ":" separator in date formats

### DIFF
--- a/pendulum/parsing/parser.py
+++ b/pendulum/parsing/parser.py
@@ -21,8 +21,8 @@ class Parser(object):
         '    (?P<classic>'  # Classic date (YYYY-MM-DD) or ordinal (YYYY-DDD)
         '        (?P<year>\d{4})'  # Year
         '        (?P<monthday>'
-        '            (?P<monthsep>-|/)?(?P<month>\d{2})'  # Month (optional)
-        '            ((?P<daysep>-|/)?(?P<day>\d{1,2}))?'  # Day (optional)
+        '            (?P<monthsep>[-/:])?(?P<month>\d{2})'  # Month (optional)
+        '            ((?P<daysep>[-/:])?(?P<day>\d{1,2}))?'  # Day (optional)
         '        )?'
         '    )'
         '    |'

--- a/tests/parsing_test/test_parser.py
+++ b/tests/parsing_test/test_parser.py
@@ -561,3 +561,15 @@ class ParserTest(AbstractTestCase):
         text = '2012-W13-8'
 
         self.assertRaises(ParserError, Parser().parse, text)
+
+    def test_exif_edge_case(self):
+        text = '2016:12:26 15:45:28'
+
+        parsed = Parser().parse(text)
+
+        self.assertEqual(2016, parsed['year'])
+        self.assertEqual(12, parsed['month'])
+        self.assertEqual(26, parsed['day'])
+        self.assertEqual(15, parsed['hour'])
+        self.assertEqual(45, parsed['minute'])
+        self.assertEqual(28, parsed['second'])


### PR DESCRIPTION
Per sdispater/pendulum#101, implements exif format (: as separator in date formats) to regex parser

- [x] Add functional test for new expected parse functionality
- [x] Test COMMON regex alteration against prior test suite