### PR TITLE
When creating without tzinfo, preserve fold value.

### DIFF
--- a/pendulum/pendulum.py
+++ b/pendulum/pendulum.py
@@ -176,7 +176,7 @@ class Pendulum(Date, datetime.datetime):
             self._second = dt.second
             self._microsecond = dt.microsecond
             self._tzinfo = dt.tzinfo
-            self._fold = getattr(dt, 'fold', fold)
+            self._fold = fold
 
         self._timestamp = None
         self._int_timestamp = None

--- a/tests/pendulum_tests/test_construct.py
+++ b/tests/pendulum_tests/test_construct.py
@@ -202,6 +202,8 @@ class ConstructTest(AbstractTestCase):
 
         d = Pendulum(2013, 3, 31, 2, 30, tzinfo='Europe/Paris', fold=0)
         self.assertPendulum(d, 2013, 3, 31, 1, 30)
+        self.assertEqual(d.fold, 0)
 
         d = Pendulum(2013, 3, 31, 2, 30, tzinfo='Europe/Paris', fold=1)
         self.assertPendulum(d, 2013, 3, 31, 3, 30)
+        self.assertEqual(d.fold, 1)


### PR DESCRIPTION
When creating a new Pendulum instance without passing in a TimezoneInfo object and using python 3.6, the internal fold parameter was not correct.  In this scenario, self._fold was being set based on the fold parameter in the underlying datetime object.  When using python3.6, this value exists, but is always set to 0 since Pendulum is not passing the fold parameter to the datetime constructor.

 - Changed self._fold to always be set based on the internal fold variable.
 - Added checks to the existing unit tests to verify that the fold parameter is being preserved.

All tests pass with python 3.6.1, did not test with any other versions.