### PR TITLE
Fix #133: Allow deepcopy on Timezone classes.

### DIFF
--- a/pendulum/tz/timezone.py
+++ b/pendulum/tz/timezone.py
@@ -24,10 +24,10 @@ class Timezone(tzinfo):
     POST_TRANSITION = 'post'
     TRANSITION_ERROR = 'error'
 
-    def __init__(self, name, transitions,
-                 tzinfos,
-                 default_tzinfo_index,
-                 utc_transition_times):
+    def __init__(self, name=None, transitions=(),
+                 tzinfos=(),
+                 default_tzinfo_index=0,
+                 utc_transition_times=[]):
         """
         Constructor.
 
@@ -457,7 +457,7 @@ class FixedTimezone(Timezone):
 
     _cache = {}
 
-    def __init__(self, offset, name=None, transition_type=None):
+    def __init__(self, offset=0, name=None, transition_type=None):
         """
         :param offset: offset to UTC in seconds.
         :type offset: int

--- a/pendulum/tz/timezone_info.py
+++ b/pendulum/tz/timezone_info.py
@@ -5,7 +5,7 @@ from datetime import tzinfo, timedelta
 
 class TimezoneInfo(tzinfo):
 
-    def __init__(self, tz, utc_offset, is_dst, dst, abbrev):
+    def __init__(self, tz=None, utc_offset=0, is_dst=False, dst=None, abbrev='GMT'):
         """
         :param tz: The parent timezone.
         :type tz: Timezone

--- a/tests/pendulum_tests/test_behavior.py
+++ b/tests/pendulum_tests/test_behavior.py
@@ -2,6 +2,7 @@
 
 import pickle
 import pendulum
+from copy import deepcopy
 from datetime import datetime, date, time, timedelta
 from pendulum import Pendulum, timezone
 from .. import AbstractTestCase
@@ -103,3 +104,14 @@ class BehaviorTest(AbstractTestCase):
         dt = pendulum.create(1941, 7, 1, tz='Europe/Amsterdam')
 
         self.assertEqual(timedelta(0, 6000), dt.dst())
+
+    def test_deepcopy(self):
+        dt = pendulum.create(1941, 7, 1, tz='Europe/Amsterdam')
+
+        self.assertEqual(dt, deepcopy(dt))
+
+
+    def test_deepcopy_datetime(self):
+        dt = pendulum.create(1941, 7, 1, tz='Europe/Amsterdam')
+
+        self.assertEqual(dt._datetime, deepcopy(dt._datetime))


### PR DESCRIPTION
I've added default values to the Timezone classes so that they can be deepcopied. I think it's appropriate to provide these as `datetime.tzinfo` also has an empty constructor.