### PR TITLE
_compat.py Use feature detection instead of version detection

### DIFF
--- a/pendulum/_compat.py
+++ b/pendulum/_compat.py
@@ -17,7 +17,7 @@ except NameError:  # Python 3
     basestring = str
 
 try:               # Python >= 3.3
-    FileNotFoundError
+    FileNotFoundError = FileNotFoundError
 except NameError:  # Python < 3.3
     FileNotFoundError = IOError  # cf PEP-3151 
 

--- a/pendulum/_compat.py
+++ b/pendulum/_compat.py
@@ -4,23 +4,22 @@ import sys
 
 PY2 = sys.version_info[0] == 2
 PY3K = sys.version_info[0] >= 3
-PY33 = sys.version_info >= (3, 3)
 PY36 = sys.version_info >= (3, 6)
 
 
-if PY2:
-    long = long
-    unicode = unicode
-    basestring = basestring
-else:
+try:               # Python 2
+    long
+    unicode
+    basestring
+except NameError:  # Python 3
     long = int
     unicode = str
     basestring = str
 
-if PY33:
-    FileNotFoundError = FileNotFoundError
-else:
-    FileNotFoundError = IOError # cf PEP-3151 
+try:               # Python >= 3.3
+    FileNotFoundError
+except NameError:  # Python < 3.3
+    FileNotFoundError = IOError  # cf PEP-3151 
 
 def decode(string, encodings=None):
     if not PY2 and not isinstance(string, bytes):
@@ -29,8 +28,7 @@ def decode(string, encodings=None):
     if PY2 and isinstance(string, unicode):
         return string
 
-    if encodings is None:
-        encodings = ['utf-8', 'latin1', 'ascii']
+    encodings = encodings or ['utf-8', 'latin1', 'ascii']
 
     for encoding in encodings:
         try:
@@ -48,8 +46,7 @@ def encode(string, encodings=None):
     if PY2 and isinstance(string, str):
         return string
 
-    if encodings is None:
-        encodings = ['utf-8', 'latin1', 'ascii']
+    encodings = encodings or ['utf-8', 'latin1', 'ascii']
 
     for encoding in encodings:
         try:

--- a/pendulum/tz/loader.py
+++ b/pendulum/tz/loader.py
@@ -6,7 +6,7 @@ from struct import unpack, calcsize
 from pytzdata import tz_file
 from pytzdata.exceptions import TimezoneNotFound
 
-from .. import _compat, _compat.FileNotFoundError as FileNotFoundError
+from .. import _compat
 from ..helpers import local_time
 from .transition import Transition
 from .transition_type import TransitionType
@@ -40,7 +40,7 @@ class Loader(object):
         try:
             with open(filepath, 'rb') as f:
                 return cls._load(f)
-        except FileNotFoundError:
+        except _compat.FileNotFoundError:
             raise ValueError('Unable to load file [{}]'.format(filepath))
 
     @classmethod

--- a/pendulum/tz/loader.py
+++ b/pendulum/tz/loader.py
@@ -6,7 +6,7 @@ from struct import unpack, calcsize
 from pytzdata import tz_file
 from pytzdata.exceptions import TimezoneNotFound
 
-from .. import _compat
+from .. import _compat, _compat.FileNotFoundError as FileNotFoundError
 from ..helpers import local_time
 from .transition import Transition
 from .transition_type import TransitionType

--- a/pendulum/tz/loader.py
+++ b/pendulum/tz/loader.py
@@ -40,7 +40,7 @@ class Loader(object):
         try:
             with open(filepath, 'rb') as f:
                 return cls._load(f)
-        except _compat.FileNotFoundError:
+        except FileNotFoundError:
             raise ValueError('Unable to load file [{}]'.format(filepath))
 
     @classmethod


### PR DESCRIPTION
https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection

On `encodings`, given the `return` statement, all other _falsey_ values are just as dangerous as `None`.