### PR TITLE
Add Period.split and Period.xsplit

### DIFF
--- a/pendulum/period.py
+++ b/pendulum/period.py
@@ -199,6 +199,21 @@ class Period(WordableIntervalMixin, BaseInterval):
             locale=locale, separator=separator, _periods=periods
         )
 
+    def split(self, unit, amount=1):
+        return list(self.xsplit(unit, amount))
+
+    def xsplit(self, unit, amount=1):
+        start_list = self.range(unit, amount)
+
+        offset = -1
+        if not self._absolute and self.invert:
+            offset = 1
+        end_list = [dt.add(microseconds=offset) for dt in start_list[1:]]
+        end_list.append(self.end)
+
+        for start, end in zip(start_list, end_list):
+            yield end - start
+
     def range(self, unit, amount=1):
         return list(self.xrange(unit, amount))
 

--- a/pendulum/period.py
+++ b/pendulum/period.py
@@ -208,7 +208,11 @@ class Period(WordableIntervalMixin, BaseInterval):
         offset = -1
         if not self._absolute and self.invert:
             offset = 1
-        end_list = [dt.add(microseconds=offset) for dt in start_list[1:]]
+
+        if isinstance(self.start, pendulum.Pendulum):
+            end_list = [dt.add(microseconds=offset) for dt in start_list[1:]]
+        else:
+            end_list = [dt.add(days=offset) for dt in start_list[1:]]
         end_list.append(self.end)
 
         for start, end in zip(start_list, end_list):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ import struct
 from unittest import TestCase
 from contextlib import contextmanager
 
-from pendulum import Pendulum, Date, Time, Interval
+from pendulum import Pendulum, Date, Time, Interval, Period
 from pendulum.tz import LocalTimezone, timezone, Timezone
 
 PY36 = sys.version_info >= (3, 6)
@@ -100,6 +100,9 @@ class AbstractTestCase(TestCase):
 
     def assertIsInstanceOfInterval(self, d):
         self.assertIsInstance(d, Interval)
+
+    def assertIsInstanceOfPeriod(self, p):
+        self.assertIsInstance(p, Period)
 
     @contextmanager
     def wrap_with_test_now(self, dt=None):

--- a/tests/period_tests/test_split.py
+++ b/tests/period_tests/test_split.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+from pendulum import Period, Pendulum, Date
+
+from .. import AbstractTestCase
+
+
+class SplitTest(AbstractTestCase):
+
+    def test_split(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 12, 45, 37)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days')
+        self.assertEqual(31, len(spl))
+        self.assertPendulum(spl[0].start, 2000, 1, 1, 12, 45, 37)
+        self.assertPendulum(spl[-1].end, 2000, 1, 31, 12, 45, 37)
+
+    def test_split_hours(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 12, 45, 37)
+
+        p = Period(dt1, dt2)
+        spl = p.split('hours',5)
+        self.assertEqual(145, len(spl))
+        self.assertPendulum(spl[0].start, 2000, 1, 1, 12, 45, 37)
+        self.assertPendulum(spl[-1].end, 2000, 1, 31, 12, 45, 37)
+
+    def test_split_no_overflow(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 11, 45, 37)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days')
+        self.assertEqual(30, len(spl))
+        self.assertPendulum(spl[0].start, 2000, 1, 1, 12, 45, 37)
+        self.assertPendulum(spl[-1].end, 2000, 1, 31, 11, 45, 37)
+
+    def test_split_inverted(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 12, 45, 37)
+
+        p = Period(dt2, dt1)
+        spl = p.split('days')
+        self.assertEqual(31, len(spl))
+        self.assertPendulum(spl[-1].end, 2000, 1, 1, 12, 45, 37)
+        self.assertPendulum(spl[0].start, 2000, 1, 31, 12, 45, 37)
+
+    def test_iter(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 12, 45, 37)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days', 1)
+        i = 0
+        for s in spl:
+            self.assertIsInstanceOfPeriod(s)
+            i += 1
+
+        self.assertEqual(31, i)
+
+    def test_contained_exactly_once(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 12, 45, 37)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days', 3)
+        for dt in p:
+            self.assertEqual(1, sum(dt in p for p in spl))
+
+    def test_contained_exactly_once_hours(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 12, 45, 37)
+
+        p = Period(dt1, dt2)
+        spl = p.split('hours', 3)
+        for dt in p:
+            self.assertEqual(1, sum(dt in p for p in spl))
+
+    def test_contained_exactly_once_boundary(self):
+        dt1 = Pendulum(2000, 1, 1)
+        dt2 = Pendulum(2000, 1, 31)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days', 3)
+        for dt in p:
+            self.assertEqual(1, sum(dt in p for p in spl))
+
+    def test_contains_exactly_once_datetime(self):
+        dt1 = Pendulum(2000, 1, 1, 12, 45, 37)
+        dt2 = Pendulum(2000, 1, 31, 12, 45, 37)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days', 3)
+        dt = datetime(2000, 1, 7)
+        self.assertEqual(1, sum(dt in p for p in spl))
+
+    def test_split_months_overflow(self):
+        dt1 = Pendulum(2016, 1, 30, tzinfo='America/Sao_Paulo')
+        dt2 = dt1.add(months=4)
+
+        p = Period(dt1, dt2)
+        spl = p.split('months')
+        self.assertPendulum(spl[0].start, 2016, 1, 30, 0, 0, 0)
+        self.assertPendulum(spl[-1].end, 2016, 5, 30, 0, 0, 0)
+
+    def test_split_with_dst(self):
+        dt1 = Pendulum(2016, 10, 14, tzinfo='America/Sao_Paulo')
+        dt2 = dt1.add(weeks=1)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days')
+        self.assertPendulum(spl[0].start, 2016, 10, 14, 0, 0, 0)
+        self.assertPendulum(spl[2].start, 2016, 10, 16, 1, 0, 0)
+        self.assertPendulum(spl[-1].end, 2016, 10, 21, 0, 0, 0)
+
+    def test_split_amount(self):
+        dt1 = Pendulum(2016, 10, 14, tzinfo='America/Sao_Paulo')
+        dt2 = dt1.add(weeks=1)
+
+        p = Period(dt1, dt2)
+        spl = p.split('days', 2)
+
+        self.assertEqual(len(spl), 4)
+        self.assertPendulum(spl[0].start, 2016, 10, 14, 0, 0, 0)
+        self.assertPendulum(spl[1].start, 2016, 10, 16, 1, 0, 0)
+        self.assertPendulum(spl[2].start, 2016, 10, 18, 0, 0, 0)
+        self.assertPendulum(spl[3].start, 2016, 10, 20, 0, 0, 0)
+        self.assertPendulum(spl[3].end, 2016, 10, 21, 0, 0, 0)


### PR DESCRIPTION
```>>> import pendulum
>>> start = pendulum.Pendulum(2000, 1, 1)
>>> end = pendulum.Pendulum(2000, 1, 10)
>>> period = pendulum.period(start, end)
>>> period.split('days',4)

[<Period [2000-01-01T00:00:00+00:00 -> 2000-01-04T23:59:59.999999+00:00]>,
<Period [2000-01-05T00:00:00+00:00 -> 2000-01-08T23:59:59.999999+00:00]>,
<Period [2000-01-09T00:00:00+00:00 -> 2000-01-10T00:00:00+00:00]>]

>>> for p in period.split('days',4):
>>>    print(p) 
    
3 days 23 hours 59 minutes 59 seconds
3 days 23 hours 59 minutes 59 seconds
1 day

>>> inverted = pendulum.Period(end, start)
>>> inverted.split('weeks')
[<Period [2000-01-10T00:00:00+00:00 -> 2000-01-03T00:00:00.000001+00:00]>, <Period [2000-01-03T00:00:00+00:00 -> 2000-01-01T00:00:00+00:00]>]
```

Fixes https://github.com/sdispater/pendulum/issues/165