### PR TITLE
Improve Pendulum.now and Pendulum.utcnow performance

### DIFF
--- a/pendulum/pendulum.py
+++ b/pendulum/pendulum.py
@@ -273,11 +273,11 @@ class Pendulum(Date, datetime.datetime):
             return test_instance
 
         if tz is None or tz == 'local':
-            dt = datetime.datetime.now()
+            dt = datetime.datetime.now(cls._local_timezone())
         elif tz is UTC or tz == 'UTC':
-            dt = datetime.datetime.utcnow().replace(tzinfo=UTC)
+            dt = datetime.datetime.now(UTC)
         else:
-            dt = datetime.datetime.utcnow().replace(tzinfo=UTC)
+            dt = datetime.datetime.now(UTC)
             tz = cls._safe_create_datetime_zone(tz)
             dt = tz.convert(dt)
 
@@ -358,7 +358,7 @@ class Pendulum(Date, datetime.datetime):
             if cls.has_test_now():
                 now = cls.get_test_now().in_tz(tz)
             else:
-                now = datetime.datetime.utcnow().replace(tzinfo=UTC)
+                now = datetime.datetime.now(UTC)
                 now = tz.convert(now)
 
             if year is None:


### PR DESCRIPTION
Per my discussion in https://github.com/sdispater/pendulum/issues/171#issuecomment-355575650 and the same reasoning as https://github.com/crsmithdev/arrow/pull/486#issuecomment-349951436, I think that `pendulum` should take advantage of the fact that `datetime.now()` takes a `tzinfo` object as an argument to provide aware datetimes.

In Python 3.6 on my Arch Linux laptop. With this patch:

```python
In [1]: from pendulum import Pendulum

In [2]: %timeit Pendulum.utcnow()
The slowest run took 4.25 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 11.4 µs per loop

In [3]: %timeit Pendulum.now('UTC')
The slowest run took 6.06 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 11.3 µs per loop

In [4]: %timeit Pendulum.now()
The slowest run took 628.80 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 18.7 µs per loop
```

Before this patch:

```python
In [1]: from pendulum import Pendulum

In [2]: %timeit Pendulum.utcnow()
The slowest run took 4.17 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 11.1 µs per loop

In [3]: %timeit Pendulum.now('UTC')
100000 loops, best of 3: 11.1 µs per loop

In [4]: %timeit Pendulum.now()
The slowest run took 228.83 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 33 µs per loop
```

I guess it doesn't have a major effect on the speed of `utcnow()` for whatever reason, but it at the very least doesn't have a *negative* performance impact, and it's also the right thing to do when constructing aware datetimes.