### PR TITLE
Fix unpickling with undefined / empty timezone name

### DIFF
--- a/pendulum/pendulum.py
+++ b/pendulum/pendulum.py
@@ -1980,16 +1980,10 @@ class Pendulum(Date, datetime.datetime):
         return(self, )
 
     def _getstate(self, protocol=3):
-        tz = self.timezone_name
-
-        # Fix for fixed timezones not being properly unpickled
-        if isinstance(self.tz, FixedTimezone):
-            tz = self.offset_hours
-
         return (
             self.year, self.month, self.day,
             self.hour, self.minute, self.second, self.microsecond,
-            tz,
+            self.tzinfo,
             self.fold
         )
 

--- a/pendulum/tz/timezone.py
+++ b/pendulum/tz/timezone.py
@@ -522,7 +522,7 @@ class FixedTimezone(Timezone):
         return (dt + self._tzinfo.adjusted_offset).replace(tzinfo=self._tzinfo)
 
     def __getinitargs__(self):
-        return self._offset
+        return (self._offset, )
 
 
 class _UTC(FixedTimezone):

--- a/tests/pendulum_tests/test_behavior.py
+++ b/tests/pendulum_tests/test_behavior.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from datetime import datetime, date, time, timedelta
 from pendulum import Pendulum, timezone
 from pendulum.tz.timezone import Timezone
+from pendulum.tz.loader import Loader
 from .. import AbstractTestCase
 
 
@@ -96,6 +97,14 @@ class BehaviorTest(AbstractTestCase):
 
     def test_pickle_with_integer_tzinfo(self):
         dt1 = Pendulum(2016, 8, 27, 12, 34, 56, 123456, 0)
+        s = pickle.dumps(dt1)
+        dt2 = pickle.loads(s)
+
+        self.assertEqual(dt1, dt2)
+
+    def test_pickle_with_empty_tzinfo_name(self):
+        empty_timezone = Timezone('', *Loader.load('Europe/Paris'))
+        dt1 = Pendulum(2016, 8, 27, 12, 34, 56, 123456, empty_timezone)
         s = pickle.dumps(dt1)
         dt2 = pickle.loads(s)
 


### PR DESCRIPTION
This PR is intended to fix #167.

Basically, the issue was that Pendulum defaults to `""` for the local timezone name [if it can't be determined properly](https://github.com/sdispater/pendulum/blob/74350b3532c96c2cdace651833e2524fc54c97e8/pendulum/tz/local_timezone.py#L161-L167), but the `tz` attribute of `Pendulum()` does not accept empty string. This was causing an error while trying to re-create a pickled instance of `Pendulum`.

To fix that, I made use of #161. Now that `TimezoneInfo` objects are picklable, we can directly use them to serialize any instance of Pendulum, rather than their string representation.

I also had to fix a small bug  in the `__getinitargs__()` method of the `FixedTimezone` class, as [it should return a tuple](https://docs.python.org/2/library/pickle.html#object.__getinitargs__) but it did not.

Any `Pendulum` instance with an empty timezone name should now be correctly unpickable.

As to why the timezone name could not be determined, it seems to be a bug with Windows 10 bash shell. Here is a discussion of another project facing the same issue: https://github.com/HowardHinnant/date/issues/102 
There does not seem to be any way to know the timezone's name. However, it is recommended to run `sudo dpkg-reconfigure tzdata` to fix it, which I did and it works fine now.