### PR TITLE
Fixed IANA tz database url

### DIFF
--- a/docs/docs/instantiation.md
+++ b/docs/docs/instantiation.md
@@ -29,8 +29,8 @@ It otherwise can be a `Timezone` instance or simply a string timezone value.
 !!!note
 
     Supported strings for timezones are the one provided
-    by the [IANA time zone database](https://www.iana.org/time-zones>).
-    
+    by the [IANA time zone database](https://www.iana.org/time-zones).
+
     The special `local` string is also supported and will return your current timezone.
 
 !!!warning


### PR DESCRIPTION
Really simple docs fix, just found this while going through them. The url currently in instantiation for the IANA time zone database is invalid, changed it to the right url.