### PR TITLE
Fix exact parsing of hour-only strings

### DIFF
--- a/pendulum/parsing/__init__.py
+++ b/pendulum/parsing/__init__.py
@@ -28,7 +28,7 @@ COMMON = re.compile(
     # Time (optional)
     '(?P<time>'
     '    (?P<timesep>\ )?'  # Separator (space)
-    '    (?P<hour>\d{1,2}):(?P<minute>\d{1,2})?(?::(?P<second>\d{1,2}))?'  # HH:mm:ss (optional mm and ss)
+    '    (?P<hour>\d{1,2})(?::(?P<minute>\d{1,2})(?::(?P<second>\d{1,2}))?)?'  # HH:mm:ss (optional mm and ss)
     # Subsecond part (optional)
     '    (?P<subsecondsection>'
     '        (?:[.|,])'  # Subsecond separator (optional)
@@ -169,7 +169,10 @@ def _parse_common(text, **options):
     # Grabbing hh:mm:ss
     hour = int(m.group('hour'))
 
-    minute = int(m.group('minute'))
+    if m.group('minute'):
+        minute = int(m.group('minute'))
+    else:
+        minute = 0
 
     if m.group('second'):
         second = int(m.group('second'))

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -43,7 +43,14 @@ def test_parse_with_timezone():
     assert 7200 == dt.offset
 
 
-def test_parse_exact():
+def test_parse_exact_datetime():
+    text = '2016-10-16T12:34:56.123456'
+
+    dt = pendulum.parse(text, exact=True)
+
+    assert isinstance(dt, pendulum.DateTime)
+    assert_datetime(dt, 2016, 10, 16, 12, 34, 56, 123456)
+
     text = '2016-10-16T12:34:56.123456+01:30'
 
     dt = pendulum.parse(text, exact=True)
@@ -52,6 +59,8 @@ def test_parse_exact():
     assert_datetime(dt, 2016, 10, 16, 12, 34, 56, 123456)
     assert 5400 == dt.offset
 
+
+def test_parse_exact_date():
     text = '2016-10-16'
 
     dt = pendulum.parse(text, exact=True)
@@ -59,6 +68,22 @@ def test_parse_exact():
     assert isinstance(dt, pendulum.Date)
     assert_date(dt, 2016, 10, 16)
 
+    text = '2016-05'
+
+    dt = pendulum.parse(text, exact=True)
+
+    assert isinstance(dt, pendulum.Date)
+    assert_date(dt, 2016, 5, 1)
+
+    text = '2000'
+
+    dt = pendulum.parse(text, exact=True)
+
+    assert isinstance(dt, pendulum.Date)
+    assert_date(dt, 2000, 1, 1)
+
+
+def test_parse_exact_time():
     text = '12:34:56.123456'
 
     dt = pendulum.parse(text, exact=True)
@@ -66,12 +91,26 @@ def test_parse_exact():
     assert isinstance(dt, pendulum.Time)
     assert_time(dt, 12, 34, 56, 123456)
 
+    text = '08:55:17'
+
+    dt = pendulum.parse(text, exact=True)
+
+    assert isinstance(dt, pendulum.Time)
+    assert_time(dt, 8, 55, 17)
+
     text = '13:00'
 
     dt = pendulum.parse(text, exact=True)
 
     assert isinstance(dt, pendulum.Time)
     assert_time(dt, 13, 0, 0)
+
+    text = '20'
+
+    dt = pendulum.parse(text, exact=True)
+
+    assert isinstance(dt, pendulum.Time)
+    assert_time(dt, 20, 0, 0)
 
 
 def test_parse_duration():


### PR DESCRIPTION
Hi.

I commented on [#210](https://github.com/sdispater/pendulum/issues/210#issuecomment-393293238) a few weeks ago about a small bug while parsing:

> However, there is still a problem with `pendulum.parse("13")` which raises an exception, but shouldn't.

I copied your previous fix and extended it so it handles parsing of times without minutes nor seconds.

Also, I added some unit tests to prevent regression on edge cases like this, and I split the `test_parse_exact()` function for better readability. 👍 