### PR TITLE
Corrects a bug on closest/farthest and extends functionality to take *tuple

### DIFF
--- a/pendulum/datetime.py
+++ b/pendulum/datetime.py
@@ -452,36 +452,43 @@ class DateTime(datetime.datetime, Date):
         )
 
     # Comparisons
-    def closest(self, dt1, dt2):
-        """
-        Get the closest date from the instance.
-
-        :type dt1: DateTime or datetime
-        :type dt2: DateTime or datetime
-
-        :rtype: DateTime
-        """
-        if dt1 < dt2:
-            return pendulum.instance(dt1)
-
-        return pendulum.instance(dt2)
-
-    def farthest(self, dt1, dt2):
+    def closest(self, dt1, dt2, *dts):
+        from functools import reduce
         """
         Get the farthest date from the instance.
 
         :type dt1: datetime.datetime
         :type dt2: datetime.datetime
+        :type dts: list[datetime.datetime,]
+
+        :rtype: DateTime
+        """
+        dt1 = pendulum.instance(dt1)
+        dt2 = pendulum.instance(dt2)
+        dts = [dt1, dt2] + [pendulum.instance(x) for x in dts]
+        dts = [(abs(self - dt), dt) for dt in dts]
+
+        return min(dts)[1]
+
+    def farthest(self, dt1, dt2, *dts):
+        from functools import reduce
+        """
+        Get the farthest date from the instance.
+
+        :type dt1: datetime.datetime
+        :type dt2: datetime.datetime
+        :type dts: list[datetime.datetime,]
 
         :rtype: DateTime
         """
         dt1 = pendulum.instance(dt1)
         dt2 = pendulum.instance(dt2)
 
-        if dt1 > dt2:
-            return dt1
+        dts = [dt1, dt2] + [pendulum.instance(x) for x in dts]
+        dts = [(abs(self - dt), dt) for dt in dts]
 
-        return dt2
+        return max(dts)[1]
+
 
     def is_future(self):
         """

--- a/tests/datetime/test_comparison.py
+++ b/tests/datetime/test_comparison.py
@@ -265,12 +265,26 @@ def test_closest():
     closest = instance.closest(dt2, dt1)
     assert closest == dt1
 
+    dts = [pendulum.datetime(2015, 5, 28, 16, 0, 0) + pendulum.duration(
+        hours=x) for x in range(4)]
+    closest = instance.closest(*dts)
+    assert closest == dts[0]
+
+    closest = instance.closest(*(dts[::-1]))
+    assert closest == dts[0]
+
 
 def test_closest_with_datetime():
     instance = pendulum.datetime(2015, 5, 28, 12, 0, 0)
     dt1 = datetime(2015, 5, 28, 11, 0, 0)
     dt2 = datetime(2015, 5, 28, 14, 0, 0)
     closest = instance.closest(dt1, dt2)
+    assert_datetime(closest, 2015, 5, 28, 11, 0, 0)
+
+    dts = [pendulum.datetime(2015, 5, 28, 16, 0, 0) + pendulum.duration(
+        hours=x) for x in range(4)]
+    closest = instance.closest(dt1, dt2, *dts)
+
     assert_datetime(closest, 2015, 5, 28, 11, 0, 0)
 
 
@@ -286,28 +300,48 @@ def test_farthest():
     instance = pendulum.datetime(2015, 5, 28, 12, 0, 0)
     dt1 = pendulum.datetime(2015, 5, 28, 11, 0, 0)
     dt2 = pendulum.datetime(2015, 5, 28, 14, 0, 0)
-    closest = instance.farthest(dt1, dt2)
-    assert closest == dt2
+    farthest = instance.farthest(dt1, dt2)
+    assert farthest == dt2
 
-    closest = instance.farthest(dt2, dt1)
-    assert closest == dt2
+    farthest = instance.farthest(dt2, dt1)
+    assert farthest == dt2
+
+    dts = [pendulum.datetime(2015, 5, 28, 16, 0, 0) + pendulum.duration(
+        hours=x) for x in range(4)]
+    farthest = instance.farthest(*dts)
+    assert farthest == dts[-1]
+
+    farthest = instance.farthest(*(dts[::-1]))
+    assert farthest == dts[-1]
+
+    f = pendulum.datetime(2010, 1, 1, 0, 0, 0)
+    assert f == instance.farthest(f, *(dts))
 
 
 def test_farthest_with_datetime():
     instance = pendulum.datetime(2015, 5, 28, 12, 0, 0)
     dt1 = datetime(2015, 5, 28, 11, 0, 0, tzinfo= pendulum.UTC)
     dt2 = datetime(2015, 5, 28, 14, 0, 0, tzinfo= pendulum.UTC)
-    closest = instance.farthest(dt1, dt2)
+    farthest = instance.farthest(dt1, dt2)
+    assert_datetime(farthest, 2015, 5, 28, 14, 0, 0)
 
-    assert_datetime(closest, 2015, 5, 28, 14, 0, 0)
+    dts = [pendulum.datetime(2015, 5, 28, 16, 0, 0) + pendulum.duration(
+        hours=x) for x in range(4)]
+    farthest = instance.farthest(dt1, dt2, *dts)
+
+    assert_datetime(farthest, 2015, 5, 28, 19, 0, 0)
 
 
 def test_farthest_with_equals():
     instance = pendulum.datetime(2015, 5, 28, 12, 0, 0)
     dt1 = pendulum.datetime(2015, 5, 28, 12, 0, 0)
     dt2 = pendulum.datetime(2015, 5, 28, 14, 0, 0)
-    closest = instance.farthest(dt1, dt2)
-    assert closest == dt2
+    farthest = instance.farthest(dt1, dt2)
+    assert farthest == dt2
+
+    dts = [pendulum.datetime(2015, 5, 28, 16, 0, 0) + pendulum.duration(hours=x) for x in range(4)]
+    farthest = instance.farthest(dt1, dt2, *dts)
+    assert farthest == dts[-1]
 
 
 def test_is_same_day():


### PR DESCRIPTION
The closest/farthest functions didn't actually consider the distance between the current instance and the two parameters. On master, the 'smaller'/'bigger' was returned regardless of the actual distance between the instance and the parameters.

``` Python
>>> a = pendulum.now()
>>> b = pendulum.now() + pendulum.duration(hours=10)
>>> c = pendulum.now() + pendulum.duration(hours=-15)
>>> a.closest(b,c) == c
True
>>> # however, the closest is actually b
>>> # similarly, using farthest, should return C but instead returns b :
>>> a.farthest(b,c) == b
True
```

In addition, I have extended the functionality to receive unpacked iterables, through * operator while keeping the initial signature and backwards compatibility.

The results of the test:

>  py27: commands succeeded
ERROR:   py35: InterpreterNotFound: python3.5
  py36: commands succeeded
  pypy: commands succeeded
ERROR:   pypy3: InterpreterNotFound: pypy3

