### PR TITLE
add id_ID localization

### DIFF
--- a/pendulum/locales/id/custom.py
+++ b/pendulum/locales/id/custom.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+"""
+id custom locale file.
+"""
+
+translations = {
+    'units': {
+        'few_second': 'beberapa menit'
+    },
+
+    # Relative time
+    'ago': '{} lalu',
+    'from_now': 'dalam {}',
+    'after': '{0} kemudian',
+    'before': '{0} yang lalu',
+
+    # Ordinals
+    'ordinal': {},
+
+    # Date formats
+    'date_formats': {
+        'LTS': 'h:mm:ss A',
+        'LT': 'h:mm A',
+        'L': 'MM/DD/YYYY',
+        'LL': 'MMMM D, YYYY',
+        'LLL': 'MMMM D, YYYY h:mm A',
+        'LLLL': 'dddd, MMMM D, YYYY h:mm A',
+    },
+}
+

--- a/pendulum/locales/id/locale.py
+++ b/pendulum/locales/id/locale.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+"""
+id locale file.
+
+It has been generated automatically and must not be modified directly.
+"""
+
+from .custom import translations as custom_translations
+
+
+locale = {
+    'plural': lambda n: 'other',
+    'ordinal': lambda n: 'other',
+    'translations': {
+        u'units': {
+            u'week': {
+                u'other': u'{0} minggu',
+            },
+            u'hour': {
+                u'other': u'{0} jam',
+            },
+            u'month': {
+                u'other': u'{0} bulan',
+            },
+            u'second': {
+                u'other': u'{0} detik',
+            },
+            u'microsecond': {
+                u'other': u'{0} mikrodetik',
+            },
+            u'year': {
+                u'other': u'{0} tahun',
+            },
+            u'day': {
+                u'other': u'{0} hari',
+            },
+            u'minute': {
+                u'other': u'{0} menit',
+            },
+        },
+        u'relative': {
+            u'week': {
+                u'past': {
+                    u'other': u'{0} minggu yang lalu',
+                },
+                u'future': {
+                    u'other': u'dalam {0} minggu',
+                },
+            },
+            u'hour': {
+                u'past': {
+                    u'other': u'{0} jam yang lalu',
+                },
+                u'future': {
+                    u'other': u'dalam {0} jam',
+                },
+            },
+            u'month': {
+                u'past': {
+                    u'other': u'{0} bulan yang lalu',
+                },
+                u'future': {
+                    u'other': u'dalam {0} bulan',
+                },
+            },
+            u'second': {
+                u'past': {
+                    u'other': u'{0} detik yang lalu',
+                },
+                u'future': {
+                    u'other': u'dalam {0} detik',
+                },
+            },
+            u'year': {
+                u'past': {
+                    u'other': u'{0} tahun yang lalu',
+                },
+                u'future': {
+                    u'other': u'dalam {0} tahun',
+                },
+            },
+            u'day': {
+                u'past': {
+                    u'other': u'{0} hari yang lalu',
+                },
+                u'future': {
+                    u'other': u'dalam {0} hari',
+                },
+            },
+            u'minute': {
+                u'past': {
+                    u'other': u'{0} menit yang lalu',
+                },
+                u'future': {
+                    u'other': u'dalam {0} menit',
+                },
+            },
+        },
+        u'months': {
+            u'wide': {
+                1: u'Januari',
+                2: u'Februari',
+                3: u'Maret',
+                4: u'April',
+                5: u'Mei',
+                6: u'Juni',
+                7: u'Juli',
+                8: u'Agustus',
+                9: u'September',
+                10: u'Oktober',
+                11: u'November',
+                12: u'Desember',
+            },
+            u'abbreviated': {
+                1: u'Jan',
+                2: u'Feb',
+                3: u'Mar',
+                4: u'Apr',
+                5: u'Mei',
+                6: u'Jun',
+                7: u'Jul',
+                8: u'Agt',
+                9: u'Sep',
+                10: u'Okt',
+                11: u'Nov',
+                12: u'Des',
+            },
+            u'narrow': {
+                1: u'J',
+                2: u'F',
+                3: u'M',
+                4: u'A',
+                5: u'M',
+                6: u'J',
+                7: u'J',
+                8: u'A',
+                9: u'S',
+                10: u'O',
+                11: u'N',
+                12: u'D',
+            },
+        },
+        u'days': {
+            u'wide': {
+                0: u'Minggu',
+                1: u'Senin',
+                2: u'Selasa',
+                3: u'Rabu',
+                4: u'Kamis',
+                5: u'Jumat',
+                6: u'Sabtu',
+            },
+            u'abbreviated': {
+                0: u'Min',
+                1: u'Sen',
+                2: u'Sel',
+                3: u'Rab',
+                4: u'Kam',
+                5: u'Jum',
+                6: u'Sab',
+            },
+            u'narrow': {
+                0: u'M',
+                1: u'S',
+                2: u'S',
+                3: u'R',
+                4: u'K',
+                5: u'J',
+                6: u'S',
+            },
+            u'short': {
+                0: u'Min',
+                1: u'Sen',
+                2: u'Sel',
+                3: u'Rab',
+                4: u'Kam',
+                5: u'Jum',
+                6: u'Sab',
+            },
+        },
+        u'day_periods': {
+            u'morning1': u'pagi',
+            u'night1': u'malam',
+            u'am': u'AM',
+            u'noon': u'tengah hari',
+            u'midnight': u'tengah malam',
+            u'afternoon1': u'siang',
+            u'evening1': u'sore',
+            u'pm': u'PM',
+        },
+    },
+    'custom': custom_translations
+}

--- a/tests/localization/test_id.py
+++ b/tests/localization/test_id.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pendulum
+
+
+locale = 'id'
+
+
+def test_diff_for_humans():
+    with pendulum.test(pendulum.datetime(2016, 8, 29)):
+        diff_for_humans()
+
+
+def diff_for_humans():
+    d = pendulum.now().subtract(seconds=1)
+    assert d.diff_for_humans(locale=locale) == 'beberapa menit lalu'
+
+    d = pendulum.now().subtract(seconds=2)
+    assert d.diff_for_humans(locale=locale) == 'beberapa menit lalu'
+
+    d = pendulum.now().subtract(minutes=1)
+    assert d.diff_for_humans(locale=locale) == '1 menit yang lalu'
+
+    d = pendulum.now().subtract(minutes=2)
+    assert d.diff_for_humans(locale=locale) == '2 menit yang lalu'
+
+    d = pendulum.now().subtract(hours=1)
+    assert d.diff_for_humans(locale=locale) == '1 jam yang lalu'
+
+    d = pendulum.now().subtract(hours=2)
+    assert d.diff_for_humans(locale=locale) == '2 jam yang lalu'
+
+    d = pendulum.now().subtract(days=1)
+    assert d.diff_for_humans(locale=locale) == '1 hari yang lalu'
+
+    d = pendulum.now().subtract(days=2)
+    assert d.diff_for_humans(locale=locale) == '2 hari yang lalu'
+
+    d = pendulum.now().subtract(weeks=1)
+    assert d.diff_for_humans(locale=locale) == '1 minggu yang lalu'
+
+    d = pendulum.now().subtract(weeks=2)
+    assert d.diff_for_humans(locale=locale) == '2 minggu yang lalu'
+
+    d = pendulum.now().subtract(months=1)
+    assert d.diff_for_humans(locale=locale) == '1 bulan yang lalu'
+
+    d = pendulum.now().subtract(months=2)
+    assert d.diff_for_humans(locale=locale) == '2 bulan yang lalu'
+
+    d = pendulum.now().subtract(years=1)
+    assert d.diff_for_humans(locale=locale) == '1 tahun yang lalu'
+
+    d = pendulum.now().subtract(years=2)
+    assert d.diff_for_humans(locale=locale) == '2 tahun yang lalu'
+
+    d = pendulum.now().add(seconds=1)
+    assert d.diff_for_humans(locale=locale) == 'dalam beberapa menit'
+
+    d = pendulum.now().add(seconds=1)
+    d2 = pendulum.now()
+    assert d.diff_for_humans(d2, locale=locale) == 'beberapa menit kemudian'
+    assert d2.diff_for_humans(d, locale=locale) == 'beberapa menit yang lalu'
+
+    assert d.diff_for_humans(d2, True, locale=locale) == 'beberapa menit'
+    assert d2.diff_for_humans(d.add(seconds=1), True,
+                              locale=locale) == 'beberapa menit'


### PR DESCRIPTION
hello @sdispater,

I'm adding localization for id_ID,.

per documentation on readme, custom.py and locale.py are generated with `clock` on Ubuntu 16.04.5 LTS.
Tests were included.

please review :)

