### PR TITLE
Corrected 'z' timezone parsing in from_format to allow underscores

### DIFF
--- a/pendulum/formatting/formatter.py
+++ b/pendulum/formatting/formatter.py
@@ -32,7 +32,7 @@ _MATCH_WORD = (
     "['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+"
     "|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}"
 )
-_MATCH_TIMEZONE = "[A-za-z0-9-+]+(/[A-Za-z0-9-+]+)?"
+_MATCH_TIMEZONE = "[A-za-z0-9-+]+(/[A-Za-z0-9-+_]+)?"
 
 
 class Formatter:

--- a/tests/datetime/test_from_format.py
+++ b/tests/datetime/test_from_format.py
@@ -92,6 +92,30 @@ def test_from_format_with_millis():
             "1975-12-25T14:15:16-05:00",
             None,
         ),
+        (
+            "1975-12-25T14:15:16 America/New_York",
+            "YYYY-MM-DDTHH:mm:ss z",
+            "1975-12-25T14:15:16-05:00",
+            None,
+        ),
+        (
+            "1975-12-25T14:15:16 Africa/Porto-Novo",
+            "YYYY-MM-DDTHH:mm:ss z",
+            "1975-12-25T14:15:16+01:00",
+            None,
+        ),
+        (
+            "1975-12-25T14:15:16 Etc/GMT+0",
+            "YYYY-MM-DDTHH:mm:ss z",
+            "1975-12-25T14:15:16+00:00",
+            None,
+        ),
+        (
+            "1975-12-25T14:15:16 W-SU",
+            "YYYY-MM-DDTHH:mm:ss z",
+            "1975-12-25T14:15:16+03:00",
+            None,
+        ),
     ],
 )
 def test_from_format(text, fmt, expected, now):


### PR DESCRIPTION
Ex: America/New_York.  Expanded tests to ensure parsing of all symbols found in pendulum.timezones.