### PR TITLE
is_utc() returns False when parsing from a UTC date

### DIFF
--- a/pendulum/datetime.py
+++ b/pendulum/datetime.py
@@ -241,7 +241,7 @@ class DateTime(datetime.datetime, Date):
         return self.offset == self.in_timezone(pendulum.local_timezone()).offset
 
     def is_utc(self):
-        return self.timezone_name == "UTC"
+        return self.offset == UTC.offset
 
     def is_dst(self):
         return self.dst() != datetime.timedelta()

--- a/tests/datetime/test_getters.py
+++ b/tests/datetime/test_getters.py
@@ -134,7 +134,10 @@ def test_utc():
     assert not pendulum.datetime(2012, 1, 1, tz="America/Toronto").is_utc()
     assert not pendulum.datetime(2012, 1, 1, tz="Europe/Paris").is_utc()
     assert pendulum.datetime(2012, 1, 1, tz="UTC").is_utc()
-    assert not pendulum.datetime(2012, 1, 1, tz="GMT").is_utc()
+    assert pendulum.datetime(2012, 1, 1, tz=0).is_utc()
+    assert not pendulum.datetime(2012, 1, 1, tz=5).is_utc()
+    # There is no time difference between Greenwich Mean Time and Coordinated Universal Time
+    assert pendulum.datetime(2012, 1, 1, tz="GMT").is_utc()
 
 
 def test_is_dst():


### PR DESCRIPTION
It is a pull request for resolving the problem of `is_utc()` method -> #293 
I created additional two assertions and prepare the code which resolves the problem without the breaking anything else, I hope.
Furthermore, I think that this method should return `True` for `"GMT"` timezone because there is no time difference between Greenwich Mean Time and Coordinated Universal Time. 