### PR TITLE
int_timestamp returns different values than timestamp()

### DIFF
--- a/pendulum/datetime.py
+++ b/pendulum/datetime.py
@@ -185,6 +185,11 @@ class DateTime(datetime.datetime, Date):
     def int_timestamp(self):
         # Workaround needed to avoid inaccuracy
         # for far into the future datetimes
+        kwargs = {"tzinfo": self.tzinfo}
+
+        if _HAS_FOLD:
+            kwargs["fold"] = self.fold
+
         dt = datetime.datetime(
             self.year,
             self.month,
@@ -193,7 +198,7 @@ class DateTime(datetime.datetime, Date):
             self.minute,
             self.second,
             self.microsecond,
-            tzinfo=self.tzinfo,
+            **kwargs
         )
 
         delta = dt - self._EPOCH


### PR DESCRIPTION
It is a pull request for resolving the problem of `int_timestamp()` property method -> #282 
I prepared the solution which is identical to `timestamp()` method without interference to the current behavior of getting timestamp as an integer.