### PR TITLE
Make Duration().in_words() return "0 milliseconds"

### DIFF
--- a/pendulum/duration.py
+++ b/pendulum/duration.py
@@ -230,10 +230,15 @@ class Duration(timedelta):
                 )
                 parts.append(translation.format(count))
 
-        if not parts and abs(self.microseconds) > 0:
-            translation = locale.translation("units.second.{}".format(locale.plural(1)))
-            us = abs(self.microseconds) / 1e6
-            parts.append(translation.format("{:.2f}".format(us)))
+        if not parts:
+            if abs(self.microseconds) > 0:
+                unit = "units.second.{}".format(locale.plural(1))
+                count = "{:.2f}".format(abs(self.microseconds) / 1e6)
+            else:
+                unit = "units.microsecond.{}".format(locale.plural(0))
+                count = 0
+            translation = locale.translation(unit)
+            parts.append(translation.format(count))
 
         return decode(separator.join(parts))
 

--- a/pendulum/period.py
+++ b/pendulum/period.py
@@ -266,10 +266,15 @@ class Period(Duration):
                 )
                 parts.append(translation.format(count))
 
-        if not parts and abs(self.microseconds) > 0:
-            translation = locale.translation("units.second.{}".format(locale.plural(1)))
-            us = abs(self.microseconds) / 1e6
-            parts.append(translation.format("{:.2f}").format(us))
+        if not parts:
+            if abs(self.microseconds) > 0:
+                unit = "units.second.{}".format(locale.plural(1))
+                count = "{:.2f}".format(abs(self.microseconds) / 1e6)
+            else:
+                unit = "units.microsecond.{}".format(locale.plural(0))
+                count = 0
+            translation = locale.translation(unit)
+            parts.append(translation.format(count))
 
         return decode(separator.join(parts))
 

--- a/tests/duration/test_in_words.py
+++ b/tests/duration/test_in_words.py
@@ -67,3 +67,9 @@ def test_subseconds_with_seconds():
     pi = pendulum.duration(seconds=12, microseconds=123456)
 
     assert pi.in_words() == "12 seconds"
+
+
+def test_duration_with_all_zero_values():
+    pi = pendulum.duration()
+
+    assert pi.in_words() == "0 microseconds"

--- a/tests/period/test_in_words.py
+++ b/tests/period/test_in_words.py
@@ -1,0 +1,66 @@
+import pendulum
+
+
+def test_week():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(start=start_date, end=start_date.add(weeks=1))
+    assert period.in_words() == "1 week"
+
+
+def test_week_and_day():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(start=start_date, end=start_date.add(weeks=1, days=1))
+    assert period.in_words() == "1 week 1 day"
+
+
+def test_all():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(
+        start=start_date,
+        end=start_date.add(years=1, months=1, days=1, seconds=1, microseconds=1),
+    )
+    assert period.in_words() == "1 year 1 month 1 day 1 second"
+
+
+def test_in_french():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(
+        start=start_date,
+        end=start_date.add(years=1, months=1, days=1, seconds=1, microseconds=1),
+    )
+    assert period.in_words(locale="fr") == "1 an 1 mois 1 jour 1 seconde"
+
+
+def test_singular_negative_values():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(start=start_date, end=start_date.subtract(days=1))
+    assert period.in_words() == "-1 day"
+
+
+def test_separator():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(
+        start=start_date,
+        end=start_date.add(years=1, months=1, days=1, seconds=1, microseconds=1),
+    )
+    assert period.in_words(separator=", ") == "1 year, 1 month, 1 day, 1 second"
+
+
+def test_subseconds():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(start=start_date, end=start_date.add(microseconds=123456))
+    assert period.in_words() == "0.12 second"
+
+
+def test_subseconds_with_seconds():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(
+        start=start_date, end=start_date.add(seconds=12, microseconds=123456)
+    )
+    assert period.in_words() == "12 seconds"
+
+
+def test_zero_period():
+    start_date = pendulum.datetime(2012, 1, 1)
+    period = pendulum.period(start=start_date, end=start_date)
+    assert period.in_words() == "0 microseconds"


### PR DESCRIPTION
It is a pull request for implementing the new `in_words()` representation for the duration or period object -> #288 