### PR TITLE
Use raw strings for regexes

### DIFF
--- a/pendulum/formatting/formatter.py
+++ b/pendulum/formatting/formatter.py
@@ -11,27 +11,27 @@ from pendulum.locales.locale import Locale
 from pendulum.utils._compat import decode
 
 
-_MATCH_1 = "\d"
-_MATCH_2 = "\d\d"
-_MATCH_3 = "\d{3}"
-_MATCH_4 = "\d{4}"
-_MATCH_6 = "[+-]?\d{6}"
-_MATCH_1_TO_2 = "\d\d?"
-_MATCH_1_TO_2_LEFT_PAD = "[0-9 ]\d?"
-_MATCH_1_TO_3 = "\d{1,3}"
-_MATCH_1_TO_4 = "\d{1,4}"
-_MATCH_1_TO_6 = "[+-]?\d{1,6}"
-_MATCH_3_TO_4 = "\d{3}\d?"
-_MATCH_5_TO_6 = "\d{5}\d?"
-_MATCH_UNSIGNED = "\d+"
-_MATCH_SIGNED = "[+-]?\d+"
-_MATCH_OFFSET = "(?i)Z|[+-]\d\d:?\d\d"
-_MATCH_SHORT_OFFSET = "(?i)Z|[+-]\d\d(?::?\d\d)?"
-_MATCH_TIMESTAMP = "[+-]?\d+(\.\d{1,6})?"
+_MATCH_1 = r"\d"
+_MATCH_2 = r"\d\d"
+_MATCH_3 = r"\d{3}"
+_MATCH_4 = r"\d{4}"
+_MATCH_6 = r"[+-]?\d{6}"
+_MATCH_1_TO_2 = r"\d\d?"
+_MATCH_1_TO_2_LEFT_PAD = r"[0-9 ]\d?"
+_MATCH_1_TO_3 = r"\d{1,3}"
+_MATCH_1_TO_4 = r"\d{1,4}"
+_MATCH_1_TO_6 = r"[+-]?\d{1,6}"
+_MATCH_3_TO_4 = r"\d{3}\d?"
+_MATCH_5_TO_6 = r"\d{5}\d?"
+_MATCH_UNSIGNED = r"\d+"
+_MATCH_SIGNED = r"[+-]?\d+"
+_MATCH_OFFSET = r"(?i)Z|[+-]\d\d:?\d\d"
+_MATCH_SHORT_OFFSET = r"(?i)Z|[+-]\d\d(?::?\d\d)?"
+_MATCH_TIMESTAMP = r"[+-]?\d+(\.\d{1,6})?"
 _MATCH_WORD = (
-    "(?i)[0-9]*"
-    "['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+"
-    "|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}"
+    r"(?i)[0-9]*"
+    r"['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+"
+    r"|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}"
 )
 _MATCH_TIMEZONE = "[A-za-z0-9-+]+(/[A-Za-z0-9-+_]+)?"
 
@@ -39,21 +39,21 @@ _MATCH_TIMEZONE = "[A-za-z0-9-+]+(/[A-Za-z0-9-+_]+)?"
 class Formatter:
 
     _TOKENS = (
-        "\[([^\[]*)\]|\\\(.)|"
-        "("
-        "Mo|MM?M?M?"
-        "|Do|DDDo|DD?D?D?|ddd?d?|do?"
-        "|E{1,4}"
-        "|w[o|w]?|W[o|W]?|Qo?"
-        "|YYYY|YY|Y"
-        "|gg(ggg?)?|GG(GGG?)?"
-        "|a|A"
-        "|hh?|HH?|kk?"
-        "|mm?|ss?|S{1,9}"
-        "|x|X"
-        "|zz?|ZZ?"
-        "|LTS|LT|LL?L?L?"
-        ")"
+        r"\[([^\[]*)\]|\\(.)|"
+        r"("
+        r"Mo|MM?M?M?"
+        r"|Do|DDDo|DD?D?D?|ddd?d?|do?"
+        r"|E{1,4}"
+        r"|w[o|w]?|W[o|W]?|Qo?"
+        r"|YYYY|YY|Y"
+        r"|gg(ggg?)?|GG(GGG?)?"
+        r"|a|A"
+        r"|hh?|HH?|kk?"
+        r"|mm?|ss?|S{1,9}"
+        r"|x|X"
+        r"|zz?|ZZ?"
+        r"|LTS|LT|LL?L?L?"
+        r")"
     )
 
     _FORMAT_RE = re.compile(_TOKENS)
@@ -67,7 +67,7 @@ class Formatter:
         "Mo": None,
         "DDDo": None,
         "Do": lambda locale: tuple(
-            "\d+{}".format(o) for o in locale.get("custom.ordinal").values()
+            r"\d+{}".format(o) for o in locale.get("custom.ordinal").values()
         ),
         "dddd": "days.wide",
         "ddd": "days.abbreviated",
@@ -607,7 +607,7 @@ class Formatter:
             unit = "month"
             match = "months.abbreviated"
         elif token == "Do":
-            parsed["day"] = int(re.match("(\d+)", value).group(1))
+            parsed["day"] = int(re.match(r"(\d+)", value).group(1))
 
             return
         elif token == "dddd":

--- a/pendulum/parsing/__init__.py
+++ b/pendulum/parsing/__init__.py
@@ -21,27 +21,27 @@ except ImportError:
 
 COMMON = re.compile(
     # Date (optional)
-    "^"
-    "(?P<date>"
-    "    (?P<classic>"  # Classic date (YYYY-MM-DD)
-    "        (?P<year>\d{4})"  # Year
-    "        (?P<monthday>"
-    "            (?P<monthsep>[/:])?(?P<month>\d{2})"  # Month (optional)
-    "            ((?P<daysep>[/:])?(?P<day>\d{2}))"  # Day (optional)
-    "        )?"
-    "    )"
-    ")?"
+    r"^"
+    r"(?P<date>"
+    r"    (?P<classic>"  # Classic date (YYYY-MM-DD)
+    r"        (?P<year>\d{4})"  # Year
+    r"        (?P<monthday>"
+    r"            (?P<monthsep>[/:])?(?P<month>\d{2})"  # Month (optional)
+    r"            ((?P<daysep>[/:])?(?P<day>\d{2}))"  # Day (optional)
+    r"        )?"
+    r"    )"
+    r")?"
     # Time (optional)
-    "(?P<time>"
-    "    (?P<timesep>\ )?"  # Separator (space)
-    "    (?P<hour>\d{1,2}):(?P<minute>\d{1,2})?(?::(?P<second>\d{1,2}))?"  # HH:mm:ss (optional mm and ss)
+    r"(?P<time>"
+    r"    (?P<timesep>\ )?"  # Separator (space)
+    r"    (?P<hour>\d{1,2}):(?P<minute>\d{1,2})?(?::(?P<second>\d{1,2}))?"  # HH:mm:ss (optional mm and ss)
     # Subsecond part (optional)
-    "    (?P<subsecondsection>"
-    "        (?:[.|,])"  # Subsecond separator (optional)
-    "        (?P<subsecond>\d{1,9})"  # Subsecond
-    "    )?"
-    ")?"
-    "$",
+    r"    (?P<subsecondsection>"
+    r"        (?:[.|,])"  # Subsecond separator (optional)
+    r"        (?P<subsecond>\d{1,9})"  # Subsecond
+    r"    )?"
+    r")?"
+    r"$",
     re.VERBOSE,
 )
 

--- a/pendulum/parsing/iso8601.py
+++ b/pendulum/parsing/iso8601.py
@@ -17,62 +17,62 @@ from .exceptions import ParserError
 
 ISO8601_DT = re.compile(
     # Date (optional)
-    "^"
-    "(?P<date>"
-    "    (?P<classic>"  # Classic date (YYYY-MM-DD) or ordinal (YYYY-DDD)
-    "        (?P<year>\d{4})"  # Year
-    "        (?P<monthday>"
-    "            (?P<monthsep>-)?(?P<month>\d{2})"  # Month (optional)
-    "            ((?P<daysep>-)?(?P<day>\d{1,2}))?"  # Day (optional)
-    "        )?"
-    "    )"
-    "    |"
-    "    (?P<isocalendar>"  # Calendar date (2016-W05 or 2016-W05-5)
-    "        (?P<isoyear>\d{4})"  # Year
-    "        (?P<weeksep>-)?"  # Separator (optional)
-    "        W"  # W separator
-    "        (?P<isoweek>\d{2})"  # Week number
-    "        (?P<weekdaysep>-)?"  # Separator (optional)
-    "        (?P<isoweekday>\d)?"  # Weekday (optional)
-    "    )"
-    ")?"
+    r"^"
+    r"(?P<date>"
+    r"    (?P<classic>"  # Classic date (YYYY-MM-DD) or ordinal (YYYY-DDD)
+    r"        (?P<year>\d{4})"  # Year
+    r"        (?P<monthday>"
+    r"            (?P<monthsep>-)?(?P<month>\d{2})"  # Month (optional)
+    r"            ((?P<daysep>-)?(?P<day>\d{1,2}))?"  # Day (optional)
+    r"        )?"
+    r"    )"
+    r"    |"
+    r"    (?P<isocalendar>"  # Calendar date (2016-W05 or 2016-W05-5)
+    r"        (?P<isoyear>\d{4})"  # Year
+    r"        (?P<weeksep>-)?"  # Separator (optional)
+    r"        W"  # W separator
+    r"        (?P<isoweek>\d{2})"  # Week number
+    r"        (?P<weekdaysep>-)?"  # Separator (optional)
+    r"        (?P<isoweekday>\d)?"  # Weekday (optional)
+    r"    )"
+    r")?"
     # Time (optional)
-    "(?P<time>"
-    "    (?P<timesep>[T\ ])?"  # Separator (T or space)
-    "    (?P<hour>\d{1,2})(?P<minsep>:)?(?P<minute>\d{1,2})?(?P<secsep>:)?(?P<second>\d{1,2})?"  # HH:mm:ss (optional mm and ss)
+    r"(?P<time>"
+    r"    (?P<timesep>[T\ ])?"  # Separator (T or space)
+    r"    (?P<hour>\d{1,2})(?P<minsep>:)?(?P<minute>\d{1,2})?(?P<secsep>:)?(?P<second>\d{1,2})?"  # HH:mm:ss (optional mm and ss)
     # Subsecond part (optional)
-    "    (?P<subsecondsection>"
-    "        (?:[.,])"  # Subsecond separator (optional)
-    "        (?P<subsecond>\d{1,9})"  # Subsecond
-    "    )?"
+    r"    (?P<subsecondsection>"
+    r"        (?:[.,])"  # Subsecond separator (optional)
+    r"        (?P<subsecond>\d{1,9})"  # Subsecond
+    r"    )?"
     # Timezone offset
-    "    (?P<tz>"
-    "        (?:[-+])\d{2}:?(?:\d{2})?|Z"  # Offset (+HH:mm or +HHmm or +HH or Z)
-    "    )?"
-    ")?"
-    "$",
+    r"    (?P<tz>"
+    r"        (?:[-+])\d{2}:?(?:\d{2})?|Z"  # Offset (+HH:mm or +HHmm or +HH or Z)
+    r"    )?"
+    r")?"
+    r"$",
     re.VERBOSE,
 )
 
 
 ISO8601_DURATION = re.compile(
-    "^P"  # Duration P indicator
+    r"^P"  # Duration P indicator
     # Years, months and days (optional)
-    "(?P<w>"
-    "    (?P<weeks>\d+(?:[.,]\d+)?W)"
-    ")?"
-    "(?P<ymd>"
-    "    (?P<years>\d+(?:[.,]\d+)?Y)?"
-    "    (?P<months>\d+(?:[.,]\d+)?M)?"
-    "    (?P<days>\d+(?:[.,]\d+)?D)?"
-    ")?"
-    "(?P<hms>"
-    "    (?P<timesep>T)"  # Separator (T)
-    "    (?P<hours>\d+(?:[.,]\d+)?H)?"
-    "    (?P<minutes>\d+(?:[.,]\d+)?M)?"
-    "    (?P<seconds>\d+(?:[.,]\d+)?S)?"
-    ")?"
-    "$",
+    r"(?P<w>"
+    r"    (?P<weeks>\d+(?:[.,]\d+)?W)"
+    r")?"
+    r"(?P<ymd>"
+    r"    (?P<years>\d+(?:[.,]\d+)?Y)?"
+    r"    (?P<months>\d+(?:[.,]\d+)?M)?"
+    r"    (?P<days>\d+(?:[.,]\d+)?D)?"
+    r")?"
+    r"(?P<hms>"
+    r"    (?P<timesep>T)"  # Separator (T)
+    r"    (?P<hours>\d+(?:[.,]\d+)?H)?"
+    r"    (?P<minutes>\d+(?:[.,]\d+)?M)?"
+    r"    (?P<seconds>\d+(?:[.,]\d+)?S)?"
+    r")?"
+    r"$",
     re.VERBOSE,
 )
 

--- a/pendulum/tz/zoneinfo/posix_timezone.py
+++ b/pendulum/tz/zoneinfo/posix_timezone.py
@@ -11,25 +11,25 @@ from pendulum.constants import MONTHS_OFFSETS, SECS_PER_DAY
 from .exceptions import InvalidPosixSpec
 
 _spec = re.compile(
-    "^"
-    "(?P<std_abbr><.*?>|[^-+,\d]{3,})"
-    "(?P<std_offset>([+-])?(\d{1,2})(:\d{2}(:\d{2})?)?)"
-    "(?P<dst_info>"
-    "    (?P<dst_abbr><.*?>|[^-+,\d]{3,})"
-    "    (?P<dst_offset>([+-])?(\d{1,2})(:\d{2}(:\d{2})?)?)?"
-    ")?"
-    "(?:,(?P<rules>"
-    "    (?P<dst_start>"
-    "        (?:J\d+|\d+|M\d{1,2}.\d.[0-6])"
-    "        (?:/(?P<dst_start_offset>([+-])?(\d+)(:\d{2}(:\d{2})?)?))?"
-    "    )"
-    "    ,"
-    "    (?P<dst_end>"
-    "        (?:J\d+|\d+|M\d{1,2}.\d.[0-6])"
-    "        (?:/(?P<dst_end_offset>([+-])?(\d+)(:\d{2}(:\d{2})?)?))?"
-    "    )"
-    "))?"
-    "$",
+    r"^"
+    r"(?P<std_abbr><.*?>|[^-+,\d]{3,})"
+    r"(?P<std_offset>([+-])?(\d{1,2})(:\d{2}(:\d{2})?)?)"
+    r"(?P<dst_info>"
+    r"    (?P<dst_abbr><.*?>|[^-+,\d]{3,})"
+    r"    (?P<dst_offset>([+-])?(\d{1,2})(:\d{2}(:\d{2})?)?)?"
+    r")?"
+    r"(?:,(?P<rules>"
+    r"    (?P<dst_start>"
+    r"        (?:J\d+|\d+|M\d{1,2}.\d.[0-6])"
+    r"        (?:/(?P<dst_start_offset>([+-])?(\d+)(:\d{2}(:\d{2})?)?))?"
+    r"    )"
+    r"    ,"
+    r"    (?P<dst_end>"
+    r"        (?:J\d+|\d+|M\d{1,2}.\d.[0-6])"
+    r"        (?:/(?P<dst_end_offset>([+-])?(\d+)(:\d{2}(:\d{2})?)?))?"
+    r"    )"
+    r"))?"
+    r"$",
     re.VERBOSE,
 )
 


### PR DESCRIPTION
Use raw strings for regexes, which should hopefully fix issue #302 by silencing the `DeprecationWarning: invalid escape sequence \d` warnings.