### PR TITLE
Fix case where transition can be None

### DIFF
--- a/pendulum/tz/timezone.py
+++ b/pendulum/tz/timezone.py
@@ -108,25 +108,26 @@ class Timezone(tzinfo):
             else:
                 transition = transition.previous
 
-        if transition.is_ambiguous(sec):
-            # Ambiguous time
-            if dst_rule == TRANSITION_ERROR:
-                raise AmbiguousTime(dt)
+        if transition:
+            if transition.is_ambiguous(sec):
+                # Ambiguous time
+                if dst_rule == TRANSITION_ERROR:
+                    raise AmbiguousTime(dt)
 
-            # We set the fold attribute for later
-            if dst_rule == POST_TRANSITION:
-                fold = 1
-        elif transition.is_missing(sec):
-            # Skipped time
-            if dst_rule == TRANSITION_ERROR:
-                raise NonExistingTime(dt)
+                # We set the fold attribute for later
+                if dst_rule == POST_TRANSITION:
+                    fold = 1
+            elif transition.is_missing(sec):
+                # Skipped time
+                if dst_rule == TRANSITION_ERROR:
+                    raise NonExistingTime(dt)
 
-            # We adjust accordingly
-            if dst_rule == POST_TRANSITION:
-                sec += transition.fix
-                fold = 1
-            else:
-                sec -= transition.fix
+                # We adjust accordingly
+                if dst_rule == POST_TRANSITION:
+                    sec += transition.fix
+                    fold = 1
+                else:
+                    sec -= transition.fix
 
         kwargs = {"tzinfo": self}
         if _HAS_FOLD or isinstance(dt, pendulum.DateTime):

--- a/tests/date/test_sub.py
+++ b/tests/date/test_sub.py
@@ -2,7 +2,7 @@ import pytest
 
 import pendulum
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from ..conftest import assert_date
 
@@ -41,6 +41,11 @@ def test_subtract_days_zero():
 
 def test_subtract_days_negative():
     assert pendulum.Date(1975, 5, 30).subtract(days=-1).day == 31
+
+
+def test_subtract_days_max():
+    delta = pendulum.now() - pendulum.instance(datetime.min)
+    assert pendulum.now().subtract(days=delta.days - 1).year == 1
 
 
 def test_subtract_weeks_positive():


### PR DESCRIPTION
When calling `.subtract(days=days)` with the maximum value ("now" - `datetime.min`), the following exception is raised:

```
>       if transition.is_ambiguous(sec):
E       AttributeError: 'NoneType' object has no attribute 'is_ambiguous'
```