### PR TITLE
Replaced windows incompatible char

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Sébastien Eustace
+Copyright (c) 2015 Sebastien Eustace
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/MIT-license
-# Copyright (c) 2015 Sébastien Eustace
+# Copyright (c) 2015 Sebastien Eustace
 
 PENDULUM_RELEASE := $$(sed -n -E "s/VERSION = \"(.+)\"/\1/p" pendulum/version.py)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pendulum"
 version = "2.0.4"
 description = "Python datetimes made easy"
-authors = ["Sébastien Eustace <sebastien@eustace.io>"]
+authors = ["Sebastien Eustace <sebastien@eustace.io>"]
 license = "MIT"
 
 readme = 'README.rst'


### PR DESCRIPTION
When pip installing under windows the char 0xe9 doesn't decode. Shame it's the e in the authors name.
Fixes #381 