### PR TITLE
`전` is more natural and familiar than `앞`.

### DIFF
--- a/pendulum/locales/ko/custom.py
+++ b/pendulum/locales/ko/custom.py
@@ -8,7 +8,7 @@ ko custom locale file.
 translations = {
     # Relative time
     "after": "{0} 뒤",
-    "before": "{0} 앞",
+    "before": "{0} 전",
     # Date formats
     "date_formats": {
         "LTS": "A h시 m분 s초",


### PR DESCRIPTION
For Koreans, `전` is more natural and familiar than `앞`.