### PR TITLE
Update string_formatting.md

### DIFF
--- a/docs/docs/string_formatting.md
+++ b/docs/docs/string_formatting.md
@@ -169,6 +169,6 @@ To escape characters in format strings, you can wrap the characters in square br
 >>> import pendulum
 
 >>> dt = pendulum.now()
->>> dt.format('[today] dddd', formatter='alternative')
+>>> dt.format('[today] dddd')
 'today Sunday'
 ```


### PR DESCRIPTION
>>>dt.format('[today] dddd', formatter='alternative') not supported keyword 'formatter'