### PR TITLE
Default to own `.fold` when calling `.replace()`

### DIFF
--- a/pendulum/datetime.py
+++ b/pendulum/datetime.py
@@ -1494,6 +1494,8 @@ class DateTime(datetime.datetime, Date):
             microsecond = self.microsecond
         if tzinfo is True:
             tzinfo = self.tzinfo
+        if fold is None:
+            fold = self.fold
 
         transition_rule = pendulum.POST_TRANSITION
         if fold is not None:

--- a/tests/datetime/test_fluent_setters.py
+++ b/tests/datetime/test_fluent_setters.py
@@ -139,8 +139,8 @@ def test_fluid_at_with_transition():
     assert 0 == new.second
 
 
-def test_replace_tzinfo_dls_off():
-    d = pendulum.datetime(2016, 3, 27, 0, 30)  # 30 min before DLS turning on
+def test_replace_tzinfo_dst_off():
+    d = pendulum.datetime(2016, 3, 27, 0, 30)  # 30 min before DST turning on
     new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
 
     assert_datetime(new, 2016, 3, 27, 0, 30)
@@ -149,7 +149,7 @@ def test_replace_tzinfo_dls_off():
     assert new.timezone_name == "Europe/Paris"
 
 
-def test_replace_tzinfo_dls_transitioning_on():
+def test_replace_tzinfo_dst_transitioning_on():
     d = pendulum.datetime(2016, 3, 27, 1, 30)  # In middle of turning on
     new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
 
@@ -159,8 +159,8 @@ def test_replace_tzinfo_dls_transitioning_on():
     assert new.timezone_name == "Europe/Paris"
 
 
-def test_replace_tzinfo_dls_on():
-    d = pendulum.datetime(2016, 10, 30, 0, 30)  # 30 min before DLS turning off
+def test_replace_tzinfo_dst_on():
+    d = pendulum.datetime(2016, 10, 30, 0, 30)  # 30 min before DST turning off
     new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
 
     assert_datetime(new, 2016, 10, 30, 0, 30)
@@ -169,7 +169,7 @@ def test_replace_tzinfo_dls_on():
     assert new.timezone_name == "Europe/Paris"
 
 
-def test_replace_tzinfo_dls_transitioning_off():
+def test_replace_tzinfo_dst_transitioning_off():
     d = pendulum.datetime(2016, 10, 30, 1, 30)  # In the middle of turning off
     new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
 

--- a/tests/datetime/test_fluent_setters.py
+++ b/tests/datetime/test_fluent_setters.py
@@ -139,18 +139,41 @@ def test_fluid_at_with_transition():
     assert 0 == new.second
 
 
-def test_replace_tzinfo():
-    d = pendulum.datetime(2016, 7, 2, 0, 41, 20)
+def test_replace_tzinfo_dls_off():
+    d = pendulum.datetime(2016, 3, 27, 0, 30)  # 30 min before DLS turning on
     new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
 
+    assert_datetime(new, 2016, 3, 27, 0, 30)
+    assert not new.is_dst()
+    assert new.offset == 3600
     assert new.timezone_name == "Europe/Paris"
 
 
-def test_replace_tzinfo_dst():
-    d = pendulum.datetime(2013, 3, 31, 2, 30)
+def test_replace_tzinfo_dls_transitioning_on():
+    d = pendulum.datetime(2016, 3, 27, 1, 30)  # In middle of turning on
     new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
 
-    assert_datetime(new, 2013, 3, 31, 3, 30)
+    assert_datetime(new, 2016, 3, 27, 1, 30)
+    assert not new.is_dst()
+    assert new.offset == 3600
+    assert new.timezone_name == "Europe/Paris"
+
+
+def test_replace_tzinfo_dls_on():
+    d = pendulum.datetime(2016, 10, 30, 0, 30)  # 30 min before DLS turning off
+    new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
+
+    assert_datetime(new, 2016, 10, 30, 0, 30)
+    assert new.is_dst()
+    assert new.offset == 7200
+    assert new.timezone_name == "Europe/Paris"
+
+
+def test_replace_tzinfo_dls_transitioning_off():
+    d = pendulum.datetime(2016, 10, 30, 1, 30)  # In the middle of turning off
+    new = d.replace(tzinfo=pendulum.timezone("Europe/Paris"))
+
+    assert_datetime(new, 2016, 10, 30, 1, 30)
     assert new.is_dst()
     assert new.offset == 7200
     assert new.timezone_name == "Europe/Paris"

--- a/tests/datetime/test_replace.py
+++ b/tests/datetime/test_replace.py
@@ -1,0 +1,59 @@
+import pendulum
+
+from ..conftest import assert_datetime
+
+
+def test_replace_tzinfo_dls_off():
+    utc = pendulum.datetime(2016, 3, 27, 0, 30)  # 30 min before DLS turning on
+    in_paris = utc.in_tz("Europe/Paris")
+
+    assert_datetime(in_paris, 2016, 3, 27, 1, 30, 0)
+
+    in_paris = in_paris.replace(second=1)
+
+    assert_datetime(in_paris, 2016, 3, 27, 1, 30, 1)
+    assert not in_paris.is_dst()
+    assert in_paris.offset == 3600
+    assert in_paris.timezone_name == "Europe/Paris"
+
+
+def test_replace_tzinfo_dls_transitioning_on():
+    utc = pendulum.datetime(2016, 3, 27, 1, 30)  # In middle of turning on
+    in_paris = utc.in_tz("Europe/Paris")
+
+    assert_datetime(in_paris, 2016, 3, 27, 3, 30, 0)
+
+    in_paris = in_paris.replace(second=1)
+
+    assert_datetime(in_paris, 2016, 3, 27, 3, 30, 1)
+    assert in_paris.is_dst()
+    assert in_paris.offset == 7200
+    assert in_paris.timezone_name == "Europe/Paris"
+
+
+def test_replace_tzinfo_dls_on():
+    utc = pendulum.datetime(2016, 10, 30, 0, 30)  # 30 min before DLS turning off
+    in_paris = utc.in_tz("Europe/Paris")
+
+    assert_datetime(in_paris, 2016, 10, 30, 2, 30, 0)
+
+    in_paris = in_paris.replace(second=1)
+
+    assert_datetime(in_paris, 2016, 10, 30, 2, 30, 1)
+    assert in_paris.is_dst()
+    assert in_paris.offset == 7200
+    assert in_paris.timezone_name == "Europe/Paris"
+
+
+def test_replace_tzinfo_dls_transitioning_off():
+    utc = pendulum.datetime(2016, 10, 30, 1, 30)  # In the middle of turning off
+    in_paris = utc.in_tz("Europe/Paris")
+
+    assert_datetime(in_paris, 2016, 10, 30, 2, 30, 0)
+
+    in_paris = in_paris.replace(second=1)
+
+    assert_datetime(in_paris, 2016, 10, 30, 2, 30, 1)
+    assert not in_paris.is_dst()
+    assert in_paris.offset == 3600
+    assert in_paris.timezone_name == "Europe/Paris"

--- a/tests/datetime/test_replace.py
+++ b/tests/datetime/test_replace.py
@@ -3,8 +3,8 @@ import pendulum
 from ..conftest import assert_datetime
 
 
-def test_replace_tzinfo_dls_off():
-    utc = pendulum.datetime(2016, 3, 27, 0, 30)  # 30 min before DLS turning on
+def test_replace_tzinfo_dst_off():
+    utc = pendulum.datetime(2016, 3, 27, 0, 30)  # 30 min before DST turning on
     in_paris = utc.in_tz("Europe/Paris")
 
     assert_datetime(in_paris, 2016, 3, 27, 1, 30, 0)
@@ -17,7 +17,7 @@ def test_replace_tzinfo_dls_off():
     assert in_paris.timezone_name == "Europe/Paris"
 
 
-def test_replace_tzinfo_dls_transitioning_on():
+def test_replace_tzinfo_dst_transitioning_on():
     utc = pendulum.datetime(2016, 3, 27, 1, 30)  # In middle of turning on
     in_paris = utc.in_tz("Europe/Paris")
 
@@ -31,8 +31,8 @@ def test_replace_tzinfo_dls_transitioning_on():
     assert in_paris.timezone_name == "Europe/Paris"
 
 
-def test_replace_tzinfo_dls_on():
-    utc = pendulum.datetime(2016, 10, 30, 0, 30)  # 30 min before DLS turning off
+def test_replace_tzinfo_dst_on():
+    utc = pendulum.datetime(2016, 10, 30, 0, 30)  # 30 min before DST turning off
     in_paris = utc.in_tz("Europe/Paris")
 
     assert_datetime(in_paris, 2016, 10, 30, 2, 30, 0)
@@ -45,7 +45,7 @@ def test_replace_tzinfo_dls_on():
     assert in_paris.timezone_name == "Europe/Paris"
 
 
-def test_replace_tzinfo_dls_transitioning_off():
+def test_replace_tzinfo_dst_transitioning_off():
     utc = pendulum.datetime(2016, 10, 30, 1, 30)  # In the middle of turning off
     in_paris = utc.in_tz("Europe/Paris")
 


### PR DESCRIPTION
After doing a lot of experiments, it seemed to me that there was a problem when calling `.replace()` during DST off-transition (i.e. in the immediate hour after the transition). Reported issue here: https://github.com/sdispater/pendulum/issues/415.

So a seemingly innocent code like this:
```
    my_new_dt = my_old_dt.replace(microseconds=0)
```
would change the datetime in more ways than simply setting microseconds to zero.

This patch makes it so that when `.replace()` is called, it respects the `.fold` flag set on the datetime itself, which seems to resolve the issue.

Now, I'm no expert in timezones myself, so this might definitely be the exact wrong approach - but my gut feeling told me that it seemed odd to just default to the `pendulum.POST_TRANSITION` rule anytime we do replace, so I figured utilizing the flag seemed the right way to go about it. Seemed more symmetrical to the surrounding code too.

I added one more test module, to explicitly test out the `.replace()` function. Wasn't sure where best to fit it, but can easily accommodate a different place for it. As it happened, one of the "fluent" tests also broke - one that is dong a `.replace(tzinfo=...)` call. So I suppose I could have put my replace tests there, but wasn't sure what "fluent" meant in this context. So I ended up adding a few more cases for those `.replace(tzinfo=` tests, to get solid coverage surrounding DST transition points. Not quite convinced if those tests are what you had in mind when you wrote the original test, so hoping I'm not deviating from the intended design.

Well - looking forwards to your feedback - feel free to push back on any/all of this.