### PR TITLE
Ensure `now()` respects DST by using `.fold` attribute

### DIFF
--- a/pendulum/__init__.py
+++ b/pendulum/__init__.py
@@ -189,8 +189,23 @@ def instance(
             # on a fixed offset
             tz = tz.utcoffset(dt).total_seconds() / 3600
 
+    transition_rule = POST_TRANSITION
+    if _HAS_FOLD:
+        if dt.fold is not None:
+            transition_rule = PRE_TRANSITION
+            if dt.fold:
+                transition_rule = POST_TRANSITION
+
     return datetime(
-        dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond, tz=tz
+        dt.year,
+        dt.month,
+        dt.day,
+        dt.hour,
+        dt.minute,
+        dt.second,
+        dt.microsecond,
+        tz=tz,
+        dst_rule=transition_rule,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ mkdocs = { version = "^1.0", python = "^3.5" }
 pymdown-extensions = "^6.0"
 pygments = "^2.2"
 markdown-include = "^0.5.1"
+freezegun = "^0.3.15"
+
 
 
 [tool.isort]

--- a/tests/datetime/test_construct.py
+++ b/tests/datetime/test_construct.py
@@ -8,8 +8,10 @@ import pendulum
 import pytest
 import pytz
 
+from freezegun import freeze_time
 from pendulum import DateTime
 from pendulum.tz import timezone
+from pendulum.utils._compat import PY36
 
 from ..conftest import assert_datetime
 
@@ -100,6 +102,50 @@ def test_now():
     in_paris = pendulum.now("Europe/Paris")
 
     assert now.hour != in_paris.hour
+
+
+@pytest.mark.skipif(not PY36, reason="fold attribute only present in Python 3.6+")
+@freeze_time("2016-03-27 00:30:00")
+def test_now_dls_off():
+    utc = pendulum.now("UTC")
+    in_paris = pendulum.now("Europe/Paris")
+    in_paris_from_utc = utc.in_tz("Europe/Paris")
+    assert in_paris.hour == 1
+    assert not in_paris.is_dst()
+    assert in_paris.isoformat() == in_paris_from_utc.isoformat()
+
+
+@pytest.mark.skipif(not PY36, reason="fold attribute only present in Python 3.6+")
+@freeze_time("2016-03-27 01:30:00")
+def test_now_dls_transitioning_on():
+    utc = pendulum.now("UTC")
+    in_paris = pendulum.now("Europe/Paris")
+    in_paris_from_utc = utc.in_tz("Europe/Paris")
+    assert in_paris.hour == 3
+    assert in_paris.is_dst()
+    assert in_paris.isoformat() == in_paris_from_utc.isoformat()
+
+
+@pytest.mark.skipif(not PY36, reason="fold attribute only present in Python 3.6+")
+@freeze_time("2016-10-30 00:30:00")
+def test_now_dls_on():
+    utc = pendulum.now("UTC")
+    in_paris = pendulum.now("Europe/Paris")
+    in_paris_from_utc = utc.in_tz("Europe/Paris")
+    assert in_paris.hour == 2
+    assert in_paris.is_dst()
+    assert in_paris.isoformat() == in_paris_from_utc.isoformat()
+
+
+@pytest.mark.skipif(not PY36, reason="fold attribute only present in Python 3.6+")
+@freeze_time("2016-10-30 01:30:00")
+def test_now_dls_transitioning_off():
+    utc = pendulum.now("UTC")
+    in_paris = pendulum.now("Europe/Paris")
+    in_paris_from_utc = utc.in_tz("Europe/Paris")
+    assert in_paris.hour == 2
+    assert not in_paris.is_dst()
+    assert in_paris.isoformat() == in_paris_from_utc.isoformat()
 
 
 def test_now_with_fixed_offset():


### PR DESCRIPTION
I found that calling `pendulum.now(my_timezone)` for a timezone that has DST, right after DST was turned off gave me different results over calling `pendulum.now('UTC').in_tz(my_timezone)`. Reported issue here: https://github.com/sdispater/pendulum/issues/417.

After poking around, it seemed to me that `pendulum.datetime()` function was defaulting to `POST_TRANSITION` as `dst_rule`, which was the path followed when calling `.now()` on the DST sensitive timezone, whereas calling `.now('UTC')` and then following that with `._in_tz(my_timezone)` did indeed do something different - it had a bit of code to figure out the transition to apply.

So - perhaps it's a bit crude, but I pretty much copied that logic over, and ran the test suite. It also seemed a bit more symmetrical, code-wise. It's likely that there's some refactoring (i.e. extract that logic out) that could be done, but I didn't want to go too far, as I'm pretty new to the library.

I then added 4 tests to make sure to cover all possible points in time w.r.t. DST transitions - before, right after turning on, during and right after turning off.

The one thing I wasn't sure about was the usage of freezegun. It's a pretty popular library however, and I've battle tested it myself quite a bit. I've also compared it to libfreezetime-which I like--but freezegun has way less overhead. I also compared it to simply changing system time.

Feel free to push back on bringing in freezegun however. I did try to mock.patch the call to `_datetime.datetime.now()`, but built-ins can't be patched of course. So freezegun just seemed like the sanest way to go about this. Unless I move the unit-tests to test the `pendulum.instance()` method, instead of `pendulum.now()`.

Well, looking forward for your feedback!