### PR TITLE
Fix subtracting negative timedelta around DST

### DIFF
--- a/pendulum/datetime.py
+++ b/pendulum/datetime.py
@@ -780,9 +780,7 @@ class DateTime(datetime.datetime, Date):
                 microseconds=delta.microseconds,
             )
 
-        return self.subtract(
-            days=delta.days, seconds=delta.seconds, microseconds=delta.microseconds
-        )
+        return self.subtract(seconds=delta.total_seconds())
 
     # DIFFERENCES
 

--- a/tests/datetime/test_sub.py
+++ b/tests/datetime/test_sub.py
@@ -231,3 +231,18 @@ def test_subtract_invalid_type():
 
     with pytest.raises(TypeError):
         "ab" - d
+
+
+def test_subtract_negative_over_dls_transitioning_off():
+    just_before_dls_ends = pendulum.datetime(
+        2019, 11, 3, 1, 30, tz="US/Pacific", dst_rule=pendulum.PRE_TRANSITION
+    )
+    plus_10_hours = just_before_dls_ends + timedelta(hours=10)
+    minus_neg_10_hours = just_before_dls_ends - timedelta(hours=-10)
+
+    # 1:30-0700 becomes 10:30-0800
+    assert plus_10_hours.hour == 10
+    assert minus_neg_10_hours.hour == 10
+    assert just_before_dls_ends.is_dst()
+    assert not plus_10_hours.is_dst()
+    assert not minus_neg_10_hours.is_dst()


### PR DESCRIPTION
Noticed that in a very specific case, subtracting a negative timedelta yielded different results than adding the same positive timedelta.

I.e. `my_dt + timedelta(hours=10) ~= my_dt - timedelta(hours=-10)`.

Digging into the git log, I found that a similar fix was done for the positive case here: https://github.com/sdispater/pendulum/commit/1ec1ad0dbdd34272d72fb750f82773f41fa8c8d7.

It seemed logical/symmetrical to do similar with the negative case, although there may have been some good reasons for why `_add_timedelta()` is different from `_subtract_timedelta()` that I'm missing.

I also threw in one test case to test specifically subtracting a negative timedelta.

Looking forward to your feedback as always.