### PR TITLE
Fix bug: week_of_month

### DIFF
--- a/pendulum/date.py
+++ b/pendulum/date.py
@@ -76,7 +76,13 @@ class Date(FormattableMixing, date):
 
     @property
     def week_of_month(self):
-        return int(math.ceil(self.day / DAYS_PER_WEEK))
+        first_day = self.replace(day=1)
+        adjusted_day = self.day + first_day.weekday()
+        week_of_mon = int(math.ceil(adjusted_day / DAYS_PER_WEEK))
+        if (first_day.weekday() > 4):
+            return week_of_mon - 1
+        else:
+            return week_of_mon
 
     @property
     def age(self):


### PR DESCRIPTION
There is a bug:

    In [1]: import pendulum

    In [2]: pendulum.parse("2020-01-01").week_of_month
    Out[2]: 1

    In [3]: pendulum.parse("2020-01-07").week_of_month
    Out[3]: 1  ==>should be 2

    In [4]: pendulum.parse("2020-01-14").week_of_month
    Out[4]: 2 ==>should be 3
