### PR TITLE
Fix pendulum.test to properly unwind after an exception

### DIFF
--- a/pendulum/helpers.py
+++ b/pendulum/helpers.py
@@ -139,10 +139,10 @@ def _sign(x):
 @contextmanager
 def test(mock):
     set_test_now(mock)
-
-    yield
-
-    set_test_now()
+    try:
+        yield
+    finally:
+        set_test_now()
 
 
 def set_test_now(test_now=None):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -190,3 +190,20 @@ def test_week_ends_at_invalid_value():
 
     with pytest.raises(ValueError):
         pendulum.week_ends_at(11)
+
+
+def test_with_test():
+    t = pendulum.datetime(2000, 1, 1)
+
+    with pendulum.test(t):
+        assert pendulum.now() == t
+
+    assert pendulum.now() != t
+
+    # Also make sure that it restores things after an exception
+    with pytest.raises(RuntimeError):
+        with pendulum.test(t):
+            assert pendulum.now() == t
+            raise RuntimeError
+
+    assert pendulum.now() != t


### PR DESCRIPTION
Previously, if an exception occurred inside a 'with pendulum.test(...)'
block, then the monkeypatch would remain in place instead of being
un-done. This could cause confusing results, as one failing test could
cause other tests to run with an unexpected mock in place and cause
other failures.