### PR TITLE
Fix the typing annotation for the return of parse()

### DIFF
--- a/pendulum/parser.py
+++ b/pendulum/parser.py
@@ -5,8 +5,11 @@ import typing
 
 import pendulum
 
+from .date import Date
 from .parsing import _Interval
 from .parsing import parse as base_parse
+from .time import Duration
+from .time import Time
 from .tz import UTC
 
 
@@ -16,7 +19,9 @@ except ImportError:
     CDuration = None
 
 
-def parse(text, **options):  # type: (str, **typing.Any) -> str
+def parse(
+    text, **options
+):  # type: (str, **typing.Any) -> typing.Union[Date, Time, Duration]
     # Use the mock now value if it exists
     options["now"] = options.get("now", pendulum.get_test_now())
 


### PR DESCRIPTION
Basically a bug fix PR based on discussion for Issue https://github.com/sdispater/pendulum/issues/450
This PR incorporates a suggestion from @shot in
https://github.com/sdispater/pendulum/pull/320/files#diff-d79c6f58aeecd540ddd61603df9184aaR17