### PR TITLE
Update range docs: microseconds as supported units

### DIFF
--- a/docs/docs/period.md
+++ b/docs/docs/period.md
@@ -136,7 +136,7 @@ If you want to iterate over a period, you can use the `range()` method:
 !!!note
 
     Supported units for `range()` are: `years`, `months`, `weeks`,
-    `days`, `hours`, `minutes` and `seconds`
+    `days`, `hours`, `minutes`, `seconds` and `microseconds`
 
 You can pass an amount for the passed unit to control the length of the gap:
 


### PR DESCRIPTION
This updates the docs to reflect that microseconds as units in range work just fine.

```python
import pendulum

start = pendulum.datetime(2000, 1, 1, microsecond=1, tz='Europe/Bratislava')  
end = pendulum.datetime(2000, 1, 1, microsecond=42, tz='Europe/Bratislava') 

period = pendulum.period(start, end) 
for dt in period.range('microseconds', 4):
    print(dt) 
```

Output
```
2000-01-01T00:00:00.000001+01:00
2000-01-01T00:00:00.000005+01:00
2000-01-01T00:00:00.000009+01:00
2000-01-01T00:00:00.000013+01:00
2000-01-01T00:00:00.000017+01:00
2000-01-01T00:00:00.000021+01:00
2000-01-01T00:00:00.000025+01:00
2000-01-01T00:00:00.000029+01:00
2000-01-01T00:00:00.000033+01:00
2000-01-01T00:00:00.000037+01:00
2000-01-01T00:00:00.000041+01:00
```