### PR TITLE
 Expose Timezone._utcoffset property for pandas compatibility

### DIFF
--- a/pendulum/tz/timezone.py
+++ b/pendulum/tz/timezone.py
@@ -234,6 +234,10 @@ class Timezone(tzinfo):
 
         return transition.utcoffset()
 
+    @property
+    def _utcoffset(self):  # type: () -> timedelta
+        return self.utcoffset(datetime.utcnow())
+
     def dst(
         self, dt  # type: Optional[_datetime]
     ):  # type: (...) -> Optional[timedelta]
@@ -309,11 +313,14 @@ class FixedTimezone(Timezone):
 
         self._name = name
         self._offset = offset
-        self._utcoffset = timedelta(seconds=offset)
 
     @property
     def offset(self):  # type: () -> int
         return self._offset
+
+    @property
+    def _utcoffset(self):  # type: () -> timedelta
+        return timedelta(seconds=self.offset)
 
     def _normalize(self, dt, dst_rule=None):  # type: (_D, Optional[str]) -> _D
         if _HAS_FOLD:

--- a/tests/tz/test_timezone.py
+++ b/tests/tz/test_timezone.py
@@ -585,6 +585,12 @@ def test_timezones_extension_can_be_disabled():
     assert dt.dst() == timedelta()
 
 
+def test_timezone_has_private_utcoffset_attribute():
+    now = pendulum.now()
+    pandas_call = now.tzinfo._utcoffset.total_seconds()
+
+    assert now.utcoffset().total_seconds() == pandas_call
+
 def test_repr():
     tz = timezone("Europe/Paris")
 

--- a/tests/tz/test_timezone.py
+++ b/tests/tz/test_timezone.py
@@ -591,6 +591,7 @@ def test_timezone_has_private_utcoffset_attribute():
 
     assert now.utcoffset().total_seconds() == pandas_call
 
+
 def test_repr():
     tz = timezone("Europe/Paris")
 


### PR DESCRIPTION
This commit allows pandas to get _utcoffset from a Timezone object, taking the transision as seen from utcnow. 

As explained by @sdispater in the issues linked below, pandas tries to access the `Timezone._utcoffset` property (which isn't currently implemented for variable Timezone objects) and subsequently tries to get `Timezone.utcoffset(None)` (which correctly returns None as it can't be determined without knowlede of date and time). This PR allows pandas to treat Timezones as if they were FixedTimezones (as returned for utcnow).

ref:
https://github.com/pandas-dev/pandas/blob/v1.0.5/pandas/_libs/tslibs/timezones.pyx#L152

Fixes https://github.com/pandas-dev/pandas/issues/15986
Closes #131 

```py
>>> import pendulum
>>> import pandas
>>> pandas.date_range(start=pendulum.yesterday(), end=pendulum.tomorrow())
DatetimeIndex(['2020-07-15 00:00:00+02:00', '2020-07-16 00:00:00+02:00',
               '2020-07-17 00:00:00+02:00'],
              dtype='datetime64[ns, Timezone('Europe/Berlin')]', freq='D')
```

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
> - [ ] Updated **documentation** for changed code.

Left this unticked, as it's a private property that users won't touch.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
