### PR TITLE
Add setuptools to the build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,5 @@ known_third_party = [
 
 
 [build-system]
-requires = ["poetry>=1.0.0b1"]
+requires = ["poetry>=1.0.0b1", "setuptools"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
With version 2.1.1 the installing with `pip install --no-binary pendulum pendulum` is failing, with the error `ModuleNotFoundError: No module named 'setuptools'`. This was highligtet in #470. I was able to fix this by adding `setuptools` to the `[build-system]` `requires`.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
