### PR TITLE
Fix parsing exception when trailing/leading slash

### DIFF
--- a/pendulum/parsing/__init__.py
+++ b/pendulum/parsing/__init__.py
@@ -212,7 +212,7 @@ class _Interval:
 
 
 def _parse_iso8601_interval(text):
-    if "/" not in text:
+    if text.count("/") != 1 or text.startswith("/") or text.endswith("/"):
         raise ParserError("Invalid interval")
 
     first, last = text.split("/")

--- a/tests/parsing/test_parsing.py
+++ b/tests/parsing/test_parsing.py
@@ -670,6 +670,17 @@ def test_invalid():
     with pytest.raises(ParserError):
         parse(text)
 
+    # Incomplete date
+    text = "/2020"
+
+    with pytest.raises(ParserError):
+        parse(text)
+
+    # Incomplete date
+    text = "2020/"
+
+    with pytest.raises(ParserError):
+        parse(text)
 
 def test_exif_edge_case():
     text = "2016:12:26 15:45:28"


### PR DESCRIPTION
Hello everybody, I am new here. A quick description of the fix: parsing anything with a trailing or leading slash issues a `IndexError`, like in
```python
>>> from pendulum.parsing import parse
>>> parse("/2020")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/pendulum/pendulum/parsing/__init__.py", line 74, in parse
    return _normalize(_parse(text, **_options), **_options)
  File "/home/ubuntu/pendulum/pendulum/parsing/__init__.py", line 115, in _parse
    return _parse_iso8601_interval(text)
  File "/home/ubuntu/pendulum/pendulum/parsing/__init__.py", line 221, in _parse_iso8601_interval
    if first[0] == "P":
IndexError: string index out of range
```

I fix the `_iso8601_interval` parsing accordingly to deal with this edge case so the outer parse could raise a proper `ValueError`.

## Pull Request Check List

- [x] Added **tests** for changed code.
   - yes, just a couple

- [x] Updated **documentation** for changed code.
  - nothing to really update IMO
