### PR TITLE
mypy: implicit_reexport

### DIFF
--- a/pendulum/__init__.py
+++ b/pendulum/__init__.py
@@ -1,3 +1,5 @@
+# mypy: implicit_reexport
+
 from __future__ import absolute_import
 
 import datetime as _datetime


### PR DESCRIPTION
Either this or an explicit `__all__` is needed to be able to use type hints in a strict setting without the using application setting this up themselves in their own `mypy.ini`.  As is there are errors such as `error: Name "pendulum.DateTime" is not defined  [name-defined]`.