### PR TITLE
Remove 'why not arrow' section from docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,55 +73,6 @@ and by default in ``UTC`` for ease of use.
 
 Pendulum also improves the standard ``timedelta`` class by providing more intuitive methods and properties.
 
-
-Why not Arrow?
-==============
-
-Arrow is the most popular datetime library for Python right now, however its behavior
-and API can be erratic and unpredictable. The ``get()`` method can receive pretty much anything
-and it will try its best to return something while silently failing to handle some cases:
-
-.. code-block:: python
-
-    arrow.get('2016-1-17')
-    # <Arrow [2016-01-01T00:00:00+00:00]>
-
-    pendulum.parse('2016-1-17')
-    # <Pendulum [2016-01-17T00:00:00+00:00]>
-
-    arrow.get('20160413')
-    # <Arrow [1970-08-22T08:06:53+00:00]>
-
-    pendulum.parse('20160413')
-    # <Pendulum [2016-04-13T00:00:00+00:00]>
-
-    arrow.get('2016-W07-5')
-    # <Arrow [2016-01-01T00:00:00+00:00]>
-
-    pendulum.parse('2016-W07-5')
-    # <Pendulum [2016-02-19T00:00:00+00:00]>
-
-    # Working with DST
-    just_before = arrow.Arrow(2013, 3, 31, 1, 59, 59, 999999, 'Europe/Paris')
-    just_after = just_before.replace(microseconds=1)
-    '2013-03-31T02:00:00+02:00'
-    # Should be 2013-03-31T03:00:00+02:00
-
-    (just_after.to('utc') - just_before.to('utc')).total_seconds()
-    -3599.999999
-    # Should be 1e-06
-
-    just_before = pendulum.datetime(2013, 3, 31, 1, 59, 59, 999999, 'Europe/Paris')
-    just_after = just_before.add(microseconds=1)
-    '2013-03-31T03:00:00+02:00'
-
-    (just_after.in_timezone('utc') - just_before.in_timezone('utc')).total_seconds()
-    1e-06
-
-Those are a few examples showing that Arrow cannot always be trusted to have a consistent
-behavior with the data you are passing to it.
-
-
 Limitations
 ===========
 


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

The "Why not Arrow?" section of the documentation is no longer relevant since all of these issues have been resolved in Arrow since version 0.17.0 (released last year):

```python
env ❯ python3
Python 3.9.5 (default, May  4 2021, 03:36:27)
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import arrow
>>> import pendulum
>>> arrow.__version__
'1.1.0'
>>> pendulum.__version__
'2.1.2'
>>> arrow.get('2016-1-17')
2016-01-17T00:00:00+00:00
>>> pendulum.parse('2016-1-17')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jadchaar/Downloads/test-arrow/env/lib/python3.9/site-packages/pendulum/parser.py", line 29, in parse
    return _parse(text, **options)
  File "/Users/jadchaar/Downloads/test-arrow/env/lib/python3.9/site-packages/pendulum/parser.py", line 45, in _parse
    parsed = base_parse(text, **options)
  File "/Users/jadchaar/Downloads/test-arrow/env/lib/python3.9/site-packages/pendulum/parsing/__init__.py", line 74, in parse
    return _normalize(_parse(text, **_options), **_options)
  File "/Users/jadchaar/Downloads/test-arrow/env/lib/python3.9/site-packages/pendulum/parsing/__init__.py", line 128, in _parse
    raise ParserError("Unable to parse string [{}]".format(text))
pendulum.parsing.exceptions.ParserError: Unable to parse string [2016-1-17]
>>> arrow.get('20160413')
2016-04-13T00:00:00+00:00
>>> pendulum.parse('20160413')
2016-04-13T00:00:00+00:00
>>> arrow.get('2016-W07-5')
2016-02-19T00:00:00+00:00
>>> pendulum.parse('2016-W07-5')
2016-02-19T00:00:00+00:00
>>> just_before = arrow.Arrow(2013, 3, 31, 1, 59, 59, 999999, 'Europe/Paris')
>>> just_before
<Arrow [2013-03-31T01:59:59.999999+01:00]>
>>> just_after = just_before.shift(microseconds=1)
>>> just_after
<Arrow [2013-03-31T03:00:00+02:00]>
>>> (just_after.to('utc') - just_before.to('utc')).total_seconds()
1e-06
>>> just_before = pendulum.datetime(2013, 3, 31, 1, 59, 59, 999999, 'Europe/Paris')
>>> just_before
DateTime(2013, 3, 31, 1, 59, 59, 999999, tzinfo=Timezone('Europe/Paris'))
>>> just_after = just_before.add(microseconds=1)
>>> just_after
DateTime(2013, 3, 31, 3, 0, 0, tzinfo=Timezone('Europe/Paris'))
>>> (just_after.in_timezone('utc') - just_before.in_timezone('utc')).total_seconds()
1e-06
```

Since all of these issues are now resolved, I think it is fair to remove this section from the documentation :). Disclaimer: I am one of the maintainers of Arrow.

Thanks in advance!

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
