### PR TITLE
Fix a typo in "Shifting time to transition" example

### DIFF
--- a/docs/docs/timezones.md
+++ b/docs/docs/timezones.md
@@ -67,7 +67,7 @@ adopt the proper behavior and apply the transition accordingly.
 >>> dt = dt.add(microseconds=1)
 '2013-03-31T03:00:00+02:00'
 >>> dt.subtract(microseconds=1)
-'2013-03-31T01:59:59.999998+01:00'
+'2013-03-31T01:59:59.999999+01:00'
 
 >>> dt = pendulum.datetime(2013, 10, 27, 2, 59, 59, 999999,
                            tz='Europe/Paris',


### PR DESCRIPTION
```python3
>>> import pendulum
>>> dt = pendulum.datetime(2013, 3, 31, 1, 59, 59, 999999, tz='Europe/Paris')
>>> print(dt)
2013-03-31T01:59:59.999999+01:00
>>> dt = dt.add(microseconds=1)
>>> print(dt)
2013-03-31T03:00:00+02:00
>>> dt.subtract(microseconds=1)
DateTime(2013, 3, 31, 1, 59, 59, 999999, tzinfo=Timezone('Europe/Paris'))
>>> print(dt.subtract(microseconds=1))
2013-03-31T01:59:59.999999+01:00
>>> 
```

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
