### PR TITLE
Fix sprintf() buffer overflow

### DIFF
--- a/pendulum/_extensions/_helpers.c
+++ b/pendulum/_extensions/_helpers.c
@@ -238,10 +238,7 @@ static int Diff_init(Diff *self, PyObject *args, PyObject *kwargs)
  */
 static PyObject *Diff_repr(Diff *self)
 {
-    char repr[82] = {0};
-
-    sprintf(
-        repr,
+    return PyUnicode_FromFormat(
         "%d years %d months %d days %d hours %d minutes %d seconds %d microseconds",
         self->years,
         self->months,
@@ -250,8 +247,6 @@ static PyObject *Diff_repr(Diff *self)
         self->minutes,
         self->seconds,
         self->microseconds);
-
-    return PyUnicode_FromString(repr);
 }
 
 /*

--- a/pendulum/parsing/_iso8601.c
+++ b/pendulum/parsing/_iso8601.c
@@ -228,7 +228,6 @@ static PyObject *FixedOffset_tzname(FixedOffset *self, PyObject *args) {
         return PyUnicode_FromString(self->tzname);
     }
 
-    char tzname_[7] = {0};
     char sign = '+';
     int offset = self->offset;
 
@@ -237,15 +236,12 @@ static PyObject *FixedOffset_tzname(FixedOffset *self, PyObject *args) {
         offset *= -1;
     }
 
-    sprintf(
-        tzname_,
+    return PyUnicode_FromFormat(
         "%c%02d:%02d",
         sign,
         offset / SECS_PER_HOUR,
         offset / SECS_PER_MIN % SECS_PER_MIN
     );
-
-    return PyUnicode_FromString(tzname_);
 }
 
 /*
@@ -368,10 +364,7 @@ static int Duration_init(Duration *self, PyObject *args, PyObject *kwargs) {
  *     )
  */
 static PyObject *Duration_repr(Duration *self) {
-    char repr[82] = {0};
-
-    sprintf(
-        repr,
+    return PyUnicode_FromFormat(
         "%d years %d months %d weeks %d days %d hours %d minutes %d seconds %d microseconds",
         self->years,
         self->months,
@@ -382,8 +375,6 @@ static PyObject *Duration_repr(Duration *self) {
         self->seconds,
         self->microseconds
     );
-
-    return PyUnicode_FromString(repr);
 }
 
 /*


### PR DESCRIPTION
C extension modules use `sprintf()` in a way that can lead to a buffer overflow if the resulting text is long enough. This is unlikely to happen with valid datetimes, but still can be triggered with some creativity. This code segfaults (at least on my machine):

```python
from pendulum.parsing import _iso8601
from pendulum._extensions import _helpers

print(repr(_iso8601.TZFixedOffset(1000000)))
print(repr(_iso8601.Duration(100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000)))
print(repr(_helpers.PreciseDiff(100000, 100000, 100000, 100000, 100000, 100000, 100000)))
```

This PR replaces `sprintf()` with `PyUnicode_FromFormat()` which constructs the buffer dynamically and is safe from overflows.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
