### PR TITLE
Fix potential null pointer dereference in new_fixed_offset_ex

### DIFF
--- a/pendulum/parsing/_iso8601.c
+++ b/pendulum/parsing/_iso8601.c
@@ -306,9 +306,10 @@ static PyTypeObject FixedOffset_type = {
 static PyObject *new_fixed_offset_ex(int offset, char *name, PyTypeObject *type) {
     FixedOffset *self = (FixedOffset *) (type->tp_alloc(type, 0));
 
-    if (self != NULL)
+    if (self != NULL) {
         self->offset = offset;
         self->tzname = name;
+    }
 
     return (PyObject *) self;
 }


### PR DESCRIPTION
The body of the `if` in `new_fixed_offset_ex()` was probably intended to contain the next two indented lines, but there are no braces around them, so the second line is executed even if `self == NULL`. This can potentially lead to a null pointer dereference if `tp_alloc()` returns `NULL`. This PR adds the missing braces.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
