### PR TITLE
docs: Fix is_birthday example

### DIFF
--- a/docs/docs/comparison.md
+++ b/docs/docs/comparison.md
@@ -64,7 +64,7 @@ the `now()` is created in the same timezone as the instance.
 
 >>> born = pendulum.datetime(1987, 4, 23)
 >>> not_birthday = pendulum.datetime(2014, 9, 26)
->>> birthday = pendulum.datetime(2014, 2, 23)
+>>> birthday = pendulum.datetime(2014, 4, 23)
 >>> past_birthday = pendulum.now().subtract(years=50)
 
 >>> born.is_birthday(not_birthday)


### PR DESCRIPTION
The example in the documentation asserts that `pendulum.datetime(1987, 4, 23).is_birthday(pendulum.datetime(2014, 2, 23))`, but that is probably just a typo.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code. **N/A**
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
