### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,7 +186,7 @@ Getting started
 ---------------
 
 To work on the Pendulum codebase, you'll want to clone the project locally
-and install the required depedendencies via `poetry <https://poetry.eustace.io>`_.
+and install the required dependencies via `poetry <https://poetry.eustace.io>`_.
 
 .. code-block:: bash
 

--- a/docs/docs/period.md
+++ b/docs/docs/period.md
@@ -27,7 +27,7 @@ instances that generated it, so that it can give access to more methods and prop
 2 # 832 for the duration
 
 # However the days property will still remain the same
-# to keep the compatiblity with the timedelta class
+# to keep the compatibility with the timedelta class
 >>> period.days
 5829
 ```


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/docs/period.md

Fixes:
- Should read `dependencies` rather than `depedendencies`.
- Should read `compatibility` rather than `compatiblity`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md