### PR TITLE
Fix typing of Timezone and ZoneInfo

### DIFF
--- a/pendulum/_extensions/helpers.py
+++ b/pendulum/_extensions/helpers.py
@@ -353,7 +353,7 @@ def _get_tzinfo_name(tzinfo: datetime.tzinfo | None) -> str | None:
 
     if hasattr(tzinfo, "key"):
         # zoneinfo timezone
-        return cast(str, cast(zoneinfo.ZoneInfo, tzinfo).key)
+        return cast(zoneinfo.ZoneInfo, tzinfo).key
     elif hasattr(tzinfo, "name"):
         # Pendulum timezone
         return cast(Timezone, tzinfo).name

--- a/pendulum/formatting/formatter.py
+++ b/pendulum/formatting/formatter.py
@@ -448,7 +448,7 @@ class Formatter:
 
         if parsed["quarter"] is not None:
             if validated["year"] is not None:
-                dt = pendulum.datetime(validated["year"], 1, 1)
+                dt = pendulum.datetime(cast(int, validated["year"]), 1, 1)
             else:
                 dt = now
 
@@ -476,8 +476,8 @@ class Formatter:
         if parsed["day_of_week"] is not None:
             dt = pendulum.datetime(
                 cast(int, validated["year"]),
-                validated["month"] or now.month,
-                validated["day"] or now.day,
+                cast(int, validated["month"]) or now.month,
+                cast(int, validated["day"]) or now.day,
             )
             dt = dt.start_of("week").subtract(days=1)
             dt = dt.next(parsed["day_of_week"])
@@ -502,9 +502,9 @@ class Formatter:
                 raise ValueError("Invalid date")
 
             pm = parsed["meridiem"] == "pm"
-            validated["hour"] %= 12
+            validated["hour"] %= 12  # type: ignore
             if pm:
-                validated["hour"] += 12
+                validated["hour"] += 12  # type: ignore
 
         if validated["month"] is None:
             if parsed["year"] is not None:

--- a/pendulum/parsing/iso8601.py
+++ b/pendulum/parsing/iso8601.py
@@ -17,6 +17,7 @@ from pendulum.helpers import week_day
 from pendulum.parsing.exceptions import ParserError
 from pendulum.tz.timezone import UTC
 from pendulum.tz.timezone import FixedTimezone
+from pendulum.tz.timezone import Timezone
 
 ISO8601_DT = re.compile(
     # Date (optional)  # noqa: E800
@@ -107,7 +108,7 @@ def parse_iso8601(
     minute = 0
     second = 0
     microsecond = 0
-    tzinfo: FixedTimezone | None = None
+    tzinfo: FixedTimezone | Timezone | None = None
 
     if m.group("date"):
         # A date has been specified

--- a/pendulum/tz/local_timezone.py
+++ b/pendulum/tz/local_timezone.py
@@ -239,7 +239,7 @@ def _get_unix_timezone(_root: str = "/") -> Timezone:
             continue
 
         with open(tzpath, "rb") as f:
-            return cast(Timezone, Timezone.from_file(f))
+            return Timezone.from_file(f)
 
     raise RuntimeError("Unable to find any timezone configuration")
 
@@ -251,7 +251,7 @@ def _tz_from_env(tzenv: str) -> Timezone:
     # TZ specifies a file
     if os.path.isfile(tzenv):
         with open(tzenv, "rb") as f:
-            return cast(Timezone, Timezone.from_file(f))
+            return Timezone.from_file(f)
 
     # TZ specifies a zoneinfo zone.
     try:

--- a/pendulum/utils/_compat.py
+++ b/pendulum/utils/_compat.py
@@ -5,9 +5,9 @@ import sys
 PYPY = hasattr(sys, "pypy_version_info")
 PY38 = sys.version_info[:2] >= (3, 8)
 
-try:
+if sys.version_info < (3, 9):
     from backports import zoneinfo
-except ImportError:
-    import zoneinfo  # type: ignore[no-redef]
+else:
+    import zoneinfo
 
 __all__ = ["zoneinfo"]


### PR DESCRIPTION
Currently the method used to import `zoneinfo` leaves it typed as `Any` in `mypy` and `Unknown` in `pyright`. This PR updates `pendulum.utils._compat` to inform type checkers of the correct type information for `zoneinfo` while leaving the import mechanism the same during runtime. With `Timezone` having the correct type info from `ZoneInfo`, a few more type errors surfaced which I took care of either by adding/removing `# type: ignore` or adding/removing `cast()` calls. Since no logic has changed at runtime, no unit tests were added.