### PR TITLE
Fix diff tests for dates

### DIFF
--- a/pendulum/date.py
+++ b/pendulum/date.py
@@ -173,7 +173,7 @@ class Date(FormattableMixin, date):
         Compares the date/month values of the two dates.
         """
         if dt is None:
-            dt = Date.today()
+            dt = self.__class__.today()
 
         instance = self.__class__(dt.year, dt.month, dt.day)
 

--- a/tests/date/test_diff.py
+++ b/tests/date/test_diff.py
@@ -9,7 +9,7 @@ import pendulum
 
 @pytest.fixture
 def today():
-    return pendulum.today().date()
+    return pendulum.Date.today()
 
 
 def test_diff_in_years_positive():


### PR DESCRIPTION
The diff tests for dates was using the day of the aware datetime as "today" rather than using `Date.today()` which led to inconsistencies.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
