### PR TITLE
FIX: from_format handling 2 digit years, resolves sdispater/pendulum#686

### DIFF
--- a/pendulum/formatting/formatter.py
+++ b/pendulum/formatting/formatter.py
@@ -550,7 +550,10 @@ class Formatter:
 
         if "Y" in token:
             if token == "YY":
-                parsed_token = now.year // 100 * 100 + parsed_token
+                if parsed_token <= 68:
+                    parsed_token += 2000
+                else:
+                    parsed_token += 1900
 
             parsed["year"] = parsed_token
         elif token == "Q":

--- a/tests/datetime/test_from_format.py
+++ b/tests/datetime/test_from_format.py
@@ -81,9 +81,8 @@ def test_from_format_with_invalid_padded_day():
         ("12/02/1999", "DD/MM/YYYY", "1999-02-12T00:00:00+00:00", None),
         ("12_02_1999", "DD_MM_YYYY", "1999-02-12T00:00:00+00:00", None),
         ("12:02:1999", "DD:MM:YYYY", "1999-02-12T00:00:00+00:00", None),
-        ("2-2-99", "D-M-YY", "2099-02-02T00:00:00+00:00", None),
-        ("2-2-99", "D-M-YY", "1999-02-02T00:00:00+00:00", "1990-01-01"),
-        ("99", "YY", "2099-01-01T00:00:00+00:00", None),
+        ("2-2-99", "D-M-YY", "1999-02-02T00:00:00+00:00", None),
+        ("99", "YY", "1999-01-01T00:00:00+00:00", None),
         ("300-1999", "DDD-YYYY", "1999-10-27T00:00:00+00:00", None),
         ("12-02-1999 2:45:10", "DD-MM-YYYY h:m:s", "1999-02-12T02:45:10+00:00", None),
         ("12-02-1999 12:45:10", "DD-MM-YYYY h:m:s", "1999-02-12T12:45:10+00:00", None),
@@ -201,3 +200,25 @@ def test_strptime():
     assert_datetime(d, 1975, 5, 21, 22, 32, 11)
     assert isinstance(d, pendulum.DateTime)
     assert d.timezone_name == "UTC"
+
+
+def test_from_format_2_digit_year():
+    """
+    Complies with open group spec for 2 digit years
+    https://pubs.opengroup.org/onlinepubs/9699919799/
+
+    "If century is not specified, then values in the range [69,99] shall
+    refer to years 1969 to 1999 inclusive, and values in the
+    range [00,68] shall refer to years 2000 to 2068 inclusive."
+    """
+    d = pendulum.from_format("00", "YY")
+    assert d.year == 2000
+
+    d = pendulum.from_format("68", "YY")
+    assert d.year == 2068
+
+    d = pendulum.from_format("69", "YY")
+    assert d.year == 1969
+
+    d = pendulum.from_format("99", "YY")
+    assert d.year == 1999


### PR DESCRIPTION
## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
Fixes #686 

This makes Pendulum compliant with the current Open Group specification for 2 digit years: https://pubs.opengroup.org/onlinepubs/9699919799/

Also matches the existing behavior of Python's own [datetime and time libraries](https://docs.python.org/3/library/time.html#module-time): 

> Function [strptime()](https://docs.python.org/3/library/time.html#time.strptime) can parse 2-digit years when given %y format code. When 2-digit years are parsed, they are converted according to the POSIX and ISO C standards: values 69–99 are mapped to 1969–1999, and values 0–68 are mapped to 2000–2068.

From the datetime library source:
```py
      if group_key == 'y':
            year = int(found_dict['y'])
            # Open Group specification for strptime() states that a %y
            #value in the range of [00, 68] is in the century 2000, while
            #[69,99] is in the century 1900
            if year <= 68:
                year += 2000
            else:
                year += 1900`
``` 