### PR TITLE
Replace inspect.stack() with traceback.extract_stack() to solve performance bottleneck

### DIFF
--- a/pendulum/datetime.py
+++ b/pendulum/datetime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import calendar
 import datetime
 import sys
+import traceback
 
 from typing import TYPE_CHECKING
 from typing import Any
@@ -1221,9 +1222,7 @@ class DateTime(datetime.datetime, Date):
             # This is a workaround for Python 3.8+
             # since calling astimezone() will call this method
             # instead of the base datetime class one.
-            import inspect
-
-            caller = inspect.stack()[1][3]
+            caller = traceback.extract_stack(limit=2)[0].name
             if caller == "astimezone":
                 return super().__add__(other)
 


### PR DESCRIPTION
Use traceback.extract_stack() instead of inspect.stack() to check upper stack method, they are at same functionality, but the traceback(5μs) is 400x faster than inspect.stack(2ms). This method affects many common operation, such as add() and from_timestamp(tz), 2ms delay typically cause performance issues.
This method was available since early py 2.x

EDIT: the performance diff is not 50x, but 400x

## Performance
### before
```python
%%timeit
inspect.stack()[1][3]
# 2.11 ms ± 14.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%%timeit
pendulum.from_timestamp(1687658855, "Asia/Shanghai")
# 2.21 ms ± 63 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
### after
```python
%%timeit
traceback.extract_stack(limit=2)[0].name
# 3.7 µs ± 73.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

%%timeit
pendulum.from_timestamp(1687658855, "Asia/Shanghai")
# 8.45 µs ± 142 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

## Calling Result Demo
```python
import inspect
import traceback

def call1(f):
    f()
def call2(f):
    call1(f)

def old():
    print("old return is->", inspect.stack()[1][3])
def new():
    print("new return is->", traceback.extract_stack(limit=2)[0].name)


call2(old)
call2(new)
```
The output is
```
old return is-> call1
new return is-> call1
```

## Pull Request Check List

- [ x ] Added **tests** for changed code. 
   No new tests required
- [ x ] Updated **documentation** for changed code.
   No new document required
