### PR TITLE
Fix: week_of_month returns negative values

### DIFF
--- a/docs/docs/attributes_properties.md
+++ b/docs/docs/attributes_properties.md
@@ -27,7 +27,7 @@ Pendulum gives access to more attributes and properties than the default ``datet
 >>> dt.day_of_year
 248
 >>> dt.week_of_month
-1
+2
 >>> dt.week_of_year
 36
 >>> dt.days_in_month

--- a/pendulum/date.py
+++ b/pendulum/date.py
@@ -27,6 +27,7 @@ from pendulum.constants import YEARS_PER_CENTURY
 from pendulum.constants import YEARS_PER_DECADE
 from pendulum.exceptions import PendulumException
 from pendulum.helpers import add_duration
+from pendulum.helpers import days_of_week
 from pendulum.interval import Interval
 from pendulum.mixins.default import FormattableMixin
 
@@ -83,8 +84,11 @@ class Date(FormattableMixin, date):
     @property
     def week_of_month(self) -> int:
         first_day_of_month = self.replace(day=1)
-
-        return self.week_of_year - first_day_of_month.week_of_year + 1
+        week_days = days_of_week()
+        first_day_index = week_days.index(first_day_of_month.day_of_week)
+        days_in_first_week = pendulum.DAYS_PER_WEEK - first_day_index
+        days_after_first_week = self.day - days_in_first_week
+        return math.ceil(days_after_first_week / pendulum.DAYS_PER_WEEK) + 1
 
     @property
     def age(self) -> int:

--- a/pendulum/helpers.py
+++ b/pendulum/helpers.py
@@ -204,6 +204,16 @@ def week_ends_at(wday: int) -> None:
     pendulum._WEEK_ENDS_AT = wday
 
 
+def days_of_week() -> None:
+    return [
+        i % pendulum.DAYS_PER_WEEK
+        for i in range(
+            pendulum._WEEK_STARTS_AT,
+            pendulum._WEEK_STARTS_AT + pendulum.DAYS_PER_WEEK,
+        )
+    ]
+
+
 __all__ = [
     "PreciseDiff",
     "days_in_year",
@@ -220,4 +230,5 @@ __all__ = [
     "get_locale",
     "week_starts_at",
     "week_ends_at",
+    "days_of_week",
 ]

--- a/tests/date/test_getters.py
+++ b/tests/date/test_getters.py
@@ -61,6 +61,9 @@ def test_week_of_month():
     assert pendulum.date(2020, 1, 1).week_of_month == 1
     assert pendulum.date(2020, 1, 7).week_of_month == 2
     assert pendulum.date(2020, 1, 14).week_of_month == 3
+    assert pendulum.date(2023, 1, 1).week_of_month == 1
+    assert pendulum.date(2023, 1, 2).week_of_month == 2
+    assert pendulum.date(2023, 1, 31).week_of_month == 6
 
 
 def test_week_of_year_first_week():


### PR DESCRIPTION
## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.


## Description

Resolves https://github.com/sdispater/pendulum/issues/587

## Changes

Using day of month instead of `week_of_year` to calculate `week_of_month`. 
