### PR TITLE
Remove useless int casting

### DIFF
--- a/pendulum/_helpers.py
+++ b/pendulum/_helpers.py
@@ -92,7 +92,7 @@ def local_time(
     for a particular transition type.
     """
     year = EPOCH_YEAR
-    seconds = int(math.floor(unix_time))
+    seconds = math.floor(unix_time)
 
     # Shift to a base year that is 400-year aligned.
     if seconds >= 0:

--- a/pendulum/date.py
+++ b/pendulum/date.py
@@ -84,7 +84,7 @@ class Date(FormattableMixin, date):
 
     @property
     def quarter(self) -> int:
-        return int(math.ceil(self.month / 3))
+        return math.ceil(self.month / 3)
 
     # String Formatting
 


### PR DESCRIPTION
This is just a tiny refactoring. In Python 3, `math.floor` and `math.ceil` return `int`, so it is not necessary to cast it explicitly like in Python 2.
