### PR TITLE
Bump version to 3.0.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [3.0.0b1] - 2023-10-01
+
+### Added
+
+- Made `instance()` support all native types (date, time, datetime). [#732](https://github.com/sdispater/pendulum/pull/732)
+
+### Changed
+
+- Dropped support for Python 3.7. [#734](https://github.com/sdispater/pendulum/pull/734)
+- Rewrote extensions in Rust. [#721](https://github.com/sdispater/pendulum/pull/721)
+- Made day of week convention more consistent across the codebase. [#731](https://github.com/sdispater/pendulum/pull/731)
+
+### Fixed
+
+- Fixed datetime string representation to match the native library. [#733](https://github.com/sdispater/pendulum/pull/733)
+- Fixed issues on some system when retrieving the local timezone. [#733](https://github.com/sdispater/pendulum/pull/733)
+- Fixed DST handling in `start_of()/end_of()` methods. [#713](https://github.com/sdispater/pendulum/pull/713)
+
+
 ## [3.0.0a1] - 2022-11-23
 
 ### Added
@@ -165,7 +184,8 @@
 
 
 
-[Unreleased]: https://github.com/sdispater/pendulum/compare/3.0.0a1...master
+[Unreleased]: https://github.com/sdispater/pendulum/compare/3.0.0b1...master
+[3.0.0b1]: https://github.com/sdispater/pendulum/releases/tag/3.0.0b1
 [3.0.0a1]: https://github.com/sdispater/pendulum/releases/tag/3.0.0a1
 [2.1.1]: https://github.com/sdispater/pendulum/releases/tag/2.1.1
 [2.1.0]: https://github.com/sdispater/pendulum/releases/tag/2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pendulum"
-version = "3.0.0a1"
+version = "3.0.0b1"
 description = "Python datetimes made easy"
 readme = "README.rst"
 requires-python = ">=3.8"
@@ -34,7 +34,7 @@ Repository = "https://github.com/sdispater/pendulum"
 
 [tool.poetry]
 name = "pendulum"
-version = "3.0.0a1"
+version = "3.0.0b1"
 description = "Python datetimes made easy"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "_pendulum"
-version = "3.0.0-alpha-1"
+version = "3.0.0-beta-1"
 dependencies = [
  "mimalloc",
  "pyo3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "_pendulum"
-version = "3.0.0-alpha-1"
+version = "3.0.0-beta-1"
 edition = "2021"
 
 [lib]

--- a/src/pendulum/__version__.py
+++ b/src/pendulum/__version__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
 
-__version__ = "3.0.0a"
+__version__ = "3.0.0b1"


### PR DESCRIPTION
### Added

- Made `instance()` support all native types (date, time, datetime). [#732](https://github.com/sdispater/pendulum/pull/732)

### Changed

- Dropped support for Python 3.7. [#734](https://github.com/sdispater/pendulum/pull/734)
- Rewrote extensions in Rust. [#721](https://github.com/sdispater/pendulum/pull/721)
- Made day of week convention more consistent across the codebase. [#731](https://github.com/sdispater/pendulum/pull/731)

### Fixed

- Fixed datetime string representation to match the native library. [#733](https://github.com/sdispater/pendulum/pull/733)
- Fixed issues on some system when retrieving the local timezone. [#733](https://github.com/sdispater/pendulum/pull/733)
- Fixed DST handling in `start_of()/end_of()` methods. [#713](https://github.com/sdispater/pendulum/pull/713)
