### PR TITLE
fix: rename period to interval in repr and tests

### DIFF
--- a/src/pendulum/duration.py
+++ b/src/pendulum/duration.py
@@ -236,7 +236,7 @@ class Duration(timedelta):
         :param locale: The locale to use. Defaults to current locale.
         :param separator: The separator to use between each unit
         """
-        periods = [
+        intervals = [
             ("year", self.years),
             ("month", self.months),
             ("week", self.weeks),
@@ -252,13 +252,13 @@ class Duration(timedelta):
         loaded_locale = pendulum.locale(locale)
 
         parts = []
-        for period in periods:
-            unit, period_count = period
-            if abs(period_count) > 0:
+        for interval in intervals:
+            unit, interval_count = interval
+            if abs(interval_count) > 0:
                 translation = loaded_locale.translation(
-                    f"units.{unit}.{loaded_locale.plural(abs(period_count))}"
+                    f"units.{unit}.{loaded_locale.plural(abs(interval_count))}"
                 )
-                parts.append(translation.format(period_count))
+                parts.append(translation.format(interval_count))
 
         if not parts:
             count: int | str = 0

--- a/src/pendulum/interval.py
+++ b/src/pendulum/interval.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 class Interval(Duration):
     """
-    A period of time between two datetimes.
+    An interval of time between two datetimes.
     """
 
     @overload
@@ -61,7 +61,9 @@ class Interval(Duration):
             or not isinstance(start, datetime)
             and isinstance(end, datetime)
         ):
-            raise ValueError("Both start and end of a Period must have the same type")
+            raise ValueError(
+                "Both start and end of an Interval must have the same type"
+            )
 
         if (
             isinstance(start, datetime)
@@ -234,13 +236,13 @@ class Interval(Duration):
 
     def in_years(self) -> int:
         """
-        Gives the duration of the Period in full years.
+        Gives the duration of the Interval in full years.
         """
         return self.years
 
     def in_months(self) -> int:
         """
-        Gives the duration of the Period in full months.
+        Gives the duration of the Interval in full months.
         """
         return self.years * MONTHS_PER_YEAR + self.months
 
@@ -267,7 +269,7 @@ class Interval(Duration):
         """
         from pendulum.locales.locale import Locale
 
-        periods = [
+        intervals = [
             ("year", self.years),
             ("month", self.months),
             ("week", self.weeks),
@@ -278,13 +280,13 @@ class Interval(Duration):
         ]
         loaded_locale: Locale = Locale.load(locale or pendulum.get_locale())
         parts = []
-        for period in periods:
-            unit, period_count = period
-            if abs(period_count) > 0:
+        for interval in intervals:
+            unit, interval_count = interval
+            if abs(interval_count) > 0:
                 translation = loaded_locale.translation(
-                    f"units.{unit}.{loaded_locale.plural(abs(period_count))}"
+                    f"units.{unit}.{loaded_locale.plural(abs(interval_count))}"
                 )
-                parts.append(translation.format(period_count))
+                parts.append(translation.format(interval_count))
 
         if not parts:
             count: str | int = 0
@@ -382,7 +384,7 @@ class Interval(Duration):
         return self.__class__(self.start, self.end, absolute=True)
 
     def __repr__(self) -> str:
-        return f"<Period [{self._start} -> {self._end}]>"
+        return f"<Interval [{self._start} -> {self._end}]>"
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/tests/datetime/test_add.py
+++ b/tests/datetime/test_add.py
@@ -259,10 +259,10 @@ def test_add_interval():
     assert_datetime(new, 2017, 3, 12, 11, 45)
 
 
-def test_period_over_midnight_tz():
+def test_interval_over_midnight_tz():
     start = pendulum.datetime(2018, 2, 25, tz="Europe/Paris")
     end = start.add(hours=1)
-    period = end - start
-    new_end = start + period
+    interval = end - start
+    new_end = start + interval
 
     assert new_end == end

--- a/tests/interval/test_add_subtract.py
+++ b/tests/interval/test_add_subtract.py
@@ -6,8 +6,8 @@ import pendulum
 def test_dst_add():
     start = pendulum.datetime(2017, 3, 7, tz="America/Toronto")
     end = start.add(days=6)
-    period = end - start
-    new_end = start + period
+    interval = end - start
+    new_end = start + interval
 
     assert new_end == end
 
@@ -15,8 +15,8 @@ def test_dst_add():
 def test_dst_add_non_variable_units():
     start = pendulum.datetime(2013, 3, 31, 1, 30, tz="Europe/Paris")
     end = start.add(hours=1)
-    period = end - start
-    new_end = start + period
+    interval = end - start
+    new_end = start + interval
 
     assert new_end == end
 
@@ -24,8 +24,8 @@ def test_dst_add_non_variable_units():
 def test_dst_subtract():
     start = pendulum.datetime(2017, 3, 7, tz="America/Toronto")
     end = start.add(days=6)
-    period = end - start
-    new_start = end - period
+    interval = end - start
+    new_start = end - interval
 
     assert new_start == start
 
@@ -33,8 +33,8 @@ def test_dst_subtract():
 def test_naive_subtract():
     start = pendulum.naive(2013, 3, 31, 1, 30)
     end = start.add(hours=1)
-    period = end - start
-    new_end = start + period
+    interval = end - start
+    new_end = start + interval
 
     assert new_end == end
 
@@ -43,7 +43,7 @@ def test_negative_difference_subtract():
     start = pendulum.datetime(2018, 5, 28, 12, 34, 56, 123456)
     end = pendulum.datetime(2018, 1, 1)
 
-    period = end - start
-    new_end = start + period
+    interval = end - start
+    new_end = start + interval
 
     assert new_end == end

--- a/tests/interval/test_behavior.py
+++ b/tests/interval/test_behavior.py
@@ -40,18 +40,18 @@ def test_comparison_to_timedelta():
     dt1 = pendulum.datetime(2016, 11, 18)
     dt2 = pendulum.datetime(2016, 11, 20)
 
-    period = dt2 - dt1
+    interval = dt2 - dt1
 
-    assert period < timedelta(days=4)
+    assert interval < timedelta(days=4)
 
 
 def test_equality_to_timedelta():
     dt1 = pendulum.datetime(2016, 11, 18)
     dt2 = pendulum.datetime(2016, 11, 20)
 
-    period = dt2 - dt1
+    interval = dt2 - dt1
 
-    assert period == timedelta(days=2)
+    assert interval == timedelta(days=2)
 
 
 def test_inequality():
@@ -59,9 +59,9 @@ def test_inequality():
     dt2 = pendulum.datetime(2016, 11, 20)
     dt3 = pendulum.datetime(2016, 11, 22)
 
-    period1 = dt2 - dt1
-    period2 = dt3 - dt2
-    period3 = dt3 - dt1
+    interval1 = dt2 - dt1
+    interval2 = dt3 - dt2
+    interval3 = dt3 - dt1
 
-    assert period1 != period2
-    assert period1 != period3
+    assert interval1 != interval2
+    assert interval1 != interval3

--- a/tests/interval/test_construct.py
+++ b/tests/interval/test_construct.py
@@ -72,17 +72,17 @@ def test_accuracy():
 def test_dst_transition():
     start = pendulum.datetime(2017, 3, 7, tz="America/Toronto")
     end = start.add(days=6)
-    period = end - start
+    interval = end - start
 
-    assert period.days == 5
-    assert period.seconds == 82800
+    assert interval.days == 5
+    assert interval.seconds == 82800
 
-    assert period.remaining_days == 6
-    assert period.hours == 0
-    assert period.remaining_seconds == 0
+    assert interval.remaining_days == 6
+    assert interval.hours == 0
+    assert interval.remaining_seconds == 0
 
-    assert period.in_days() == 6
-    assert period.in_hours() == 5 * 24 + 23
+    assert interval.in_days() == 6
+    assert interval.in_hours() == 5 * 24 + 23
 
 
 def test_timedelta_behavior():
@@ -108,14 +108,14 @@ def test_timedelta_behavior():
 def test_different_timezones_same_time():
     dt1 = pendulum.datetime(2013, 3, 31, 1, 30, tz="Europe/Paris")
     dt2 = pendulum.datetime(2013, 4, 1, 1, 30, tz="Europe/Paris")
-    period = dt2 - dt1
+    interval = dt2 - dt1
 
-    assert period.in_words() == "1 day"
-    assert period.in_hours() == 23
+    assert interval.in_words() == "1 day"
+    assert interval.in_hours() == 23
 
     dt1 = pendulum.datetime(2013, 3, 31, 1, 30, tz="Europe/Paris")
     dt2 = pendulum.datetime(2013, 4, 1, 1, 30, tz="America/Toronto")
-    period = dt2 - dt1
+    interval = dt2 - dt1
 
-    assert period.in_words() == "1 day 5 hours"
-    assert period.in_hours() == 29
+    assert interval.in_words() == "1 day 5 hours"
+    assert interval.in_hours() == 29

--- a/tests/interval/test_hashing.py
+++ b/tests/interval/test_hashing.py
@@ -3,21 +3,21 @@ from __future__ import annotations
 import pendulum
 
 
-def test_periods_with_same_duration_and_different_dates():
+def test_intervals_with_same_duration_and_different_dates():
     day1 = pendulum.DateTime(2018, 1, 1)
     day2 = pendulum.DateTime(2018, 1, 2)
     day3 = pendulum.DateTime(2018, 1, 2)
 
-    period1 = day2 - day1
-    period2 = day3 - day2
+    interval1 = day2 - day1
+    interval2 = day3 - day2
 
-    assert period1 != period2
-    assert len({period1, period2}) == 2
+    assert interval1 != interval2
+    assert len({interval1, interval2}) == 2
 
 
-def test_periods_with_same_dates():
-    period1 = pendulum.DateTime(2018, 1, 2) - pendulum.DateTime(2018, 1, 1)
-    period2 = pendulum.DateTime(2018, 1, 2) - pendulum.DateTime(2018, 1, 1)
+def test_intervals_with_same_dates():
+    interval1 = pendulum.DateTime(2018, 1, 2) - pendulum.DateTime(2018, 1, 1)
+    interval2 = pendulum.DateTime(2018, 1, 2) - pendulum.DateTime(2018, 1, 1)
 
-    assert period1 == period2
-    assert len({period1, period2}) == 1
+    assert interval1 == interval2
+    assert len({interval1, interval2}) == 1

--- a/tests/interval/test_in_words.py
+++ b/tests/interval/test_in_words.py
@@ -5,66 +5,66 @@ import pendulum
 
 def test_week():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(start=start_date, end=start_date.add(weeks=1))
-    assert period.in_words() == "1 week"
+    interval = pendulum.interval(start=start_date, end=start_date.add(weeks=1))
+    assert interval.in_words() == "1 week"
 
 
 def test_week_and_day():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(start=start_date, end=start_date.add(weeks=1, days=1))
-    assert period.in_words() == "1 week 1 day"
+    interval = pendulum.interval(start=start_date, end=start_date.add(weeks=1, days=1))
+    assert interval.in_words() == "1 week 1 day"
 
 
 def test_all():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(
+    interval = pendulum.interval(
         start=start_date,
         end=start_date.add(years=1, months=1, days=1, seconds=1, microseconds=1),
     )
-    assert period.in_words() == "1 year 1 month 1 day 1 second"
+    assert interval.in_words() == "1 year 1 month 1 day 1 second"
 
 
 def test_in_french():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(
+    interval = pendulum.interval(
         start=start_date,
         end=start_date.add(years=1, months=1, days=1, seconds=1, microseconds=1),
     )
-    assert period.in_words(locale="fr") == "1 an 1 mois 1 jour 1 seconde"
+    assert interval.in_words(locale="fr") == "1 an 1 mois 1 jour 1 seconde"
 
 
 def test_singular_negative_values():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(start=start_date, end=start_date.subtract(days=1))
-    assert period.in_words() == "-1 day"
+    interval = pendulum.interval(start=start_date, end=start_date.subtract(days=1))
+    assert interval.in_words() == "-1 day"
 
 
 def test_separator():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(
+    interval = pendulum.interval(
         start=start_date,
         end=start_date.add(years=1, months=1, days=1, seconds=1, microseconds=1),
     )
-    assert period.in_words(separator=", ") == "1 year, 1 month, 1 day, 1 second"
+    assert interval.in_words(separator=", ") == "1 year, 1 month, 1 day, 1 second"
 
 
 def test_subseconds():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(
+    interval = pendulum.interval(
         start=start_date, end=start_date.add(microseconds=123456)
     )
-    assert period.in_words() == "0.12 second"
+    assert interval.in_words() == "0.12 second"
 
 
 def test_subseconds_with_seconds():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(
+    interval = pendulum.interval(
         start=start_date, end=start_date.add(seconds=12, microseconds=123456)
     )
-    assert period.in_words() == "12 seconds"
+    assert interval.in_words() == "12 seconds"
 
 
-def test_zero_period():
+def test_zero_interval():
     start_date = pendulum.datetime(2012, 1, 1)
-    period = pendulum.interval(start=start_date, end=start_date)
-    assert period.in_words() == "0 microseconds"
+    interval = pendulum.interval(start=start_date, end=start_date)
+    assert interval.in_words() == "0 microseconds"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -98,33 +98,33 @@ def test_parse_duration() -> None:
 def test_parse_interval() -> None:
     text = "2008-05-11T15:30:00Z/P1Y2M10DT2H30M"
 
-    period = pendulum.parse(text)
+    interval = pendulum.parse(text)
 
-    assert isinstance(period, pendulum.Interval)
-    assert_datetime(period.start, 2008, 5, 11, 15, 30, 0, 0)
-    assert period.start.offset == 0
-    assert_datetime(period.end, 2009, 7, 21, 18, 0, 0, 0)
-    assert period.end.offset == 0
+    assert isinstance(interval, pendulum.Interval)
+    assert_datetime(interval.start, 2008, 5, 11, 15, 30, 0, 0)
+    assert interval.start.offset == 0
+    assert_datetime(interval.end, 2009, 7, 21, 18, 0, 0, 0)
+    assert interval.end.offset == 0
 
     text = "P1Y2M10DT2H30M/2008-05-11T15:30:00Z"
 
-    period = pendulum.parse(text)
+    interval = pendulum.parse(text)
 
-    assert isinstance(period, pendulum.Interval)
-    assert_datetime(period.start, 2007, 3, 1, 13, 0, 0, 0)
-    assert period.start.offset == 0
-    assert_datetime(period.end, 2008, 5, 11, 15, 30, 0, 0)
-    assert period.end.offset == 0
+    assert isinstance(interval, pendulum.Interval)
+    assert_datetime(interval.start, 2007, 3, 1, 13, 0, 0, 0)
+    assert interval.start.offset == 0
+    assert_datetime(interval.end, 2008, 5, 11, 15, 30, 0, 0)
+    assert interval.end.offset == 0
 
     text = "2007-03-01T13:00:00Z/2008-05-11T15:30:00Z"
 
-    period = pendulum.parse(text)
+    interval = pendulum.parse(text)
 
-    assert isinstance(period, pendulum.Interval)
-    assert_datetime(period.start, 2007, 3, 1, 13, 0, 0, 0)
-    assert period.start.offset == 0
-    assert_datetime(period.end, 2008, 5, 11, 15, 30, 0, 0)
-    assert period.end.offset == 0
+    assert isinstance(interval, pendulum.Interval)
+    assert_datetime(interval.start, 2007, 3, 1, 13, 0, 0, 0)
+    assert interval.start.offset == 0
+    assert_datetime(interval.end, 2008, 5, 11, 15, 30, 0, 0)
+    assert interval.end.offset == 0
 
 
 def test_parse_now() -> None:


### PR DESCRIPTION
Hi @sdispater @Secrus!

This PR renames the remaining mentions of `period`/`Period` to `interval`/`Interval`, where it makes sense.

- Rename `Period` to `Interval` in 
  - `Interval.__repr__` 
  - `ValueError` message of `Interval.__new__`
  - docstrings of some methods in `Interval`
- Rename `period` to `interval` (mostly in tests) for a more consistent codebase. I left the `docs` untouched.

A quick `rg` search will show the only mentions left of `period`/`Period` are in `docs/`, `formatting/`, `locales/`, `CHANGELOG.md` or `clock`

PS: Thanks for the great library! I have relied on it a lot, both for professional and personal projects.
PPS: I have some free time on my hands in the next couple of months and would happily contribute more, if you guys have any suggestions.

## Pull Request Check List

- [x] ~~Added~~ Updated **tests** for changed code.
- [ ] Updated **documentation** for changed code.
