### PR TITLE
Add setuptools as build dependency on Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,5 +77,8 @@ known_third_party = [
 
 
 [build-system]
-requires = ["poetry-core>=1.0.0a9"]
+requires = [
+    "poetry-core>=1.0.0a9",
+    "setuptools>=67.2.0; python_version>='3.12'",
+]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Fix #696. This implements the lowest effort solution, adding setuptools as a build dependency on Python 3.12 and later, which injects distutils automatically back into the environment for
compatibility. I’ll leave it to the maintainers to decide whether it is worthwhile to maintain this separately from Pendulum 3.