### PR TITLE
Release 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [3.0.0] - 2023-12-16
+
+### Changed
+
+- Relaxed dependency constraints. [#760](https://github.com/sdispater/pendulum/pull/760)
+- The testing helpers are now  optional and must be opted-in via the `test` extra. [#778](https://github.com/sdispater/pendulum/pull/778)
+
+### Fixed
+
+- Removed remaining mentions of periods instead of intervals. [#757](https://github.com/sdispater/pendulum/pull/757)
+- Fixed the behavior of the `week_of_month` property for edge cases in January and December. [#774](https://github.com/sdispater/pendulum/pull/774)
+- Fixed the handling of the `fold` attribute when deep-copying a `DateTime` instance. [#776](https://github.com/sdispater/pendulum/pull/776)
+- Fixed errors where hours and days were not handled properly when adding durations. [#775](https://github.com/sdispater/pendulum/pull/775)
+- Fixed errors where hours and days were not handled properly when adding durations. [#775](https://github.com/sdispater/pendulum/pull/775)
+
+
 ## [3.0.0b1] - 2023-10-01
 
 ### Added
@@ -184,7 +200,8 @@
 
 
 
-[Unreleased]: https://github.com/sdispater/pendulum/compare/3.0.0b1...master
+[Unreleased]: https://github.com/sdispater/pendulum/compare/3.0.0...master
+[3.0.0]: https://github.com/sdispater/pendulum/releases/tag/3.0.0
 [3.0.0b1]: https://github.com/sdispater/pendulum/releases/tag/3.0.0b1
 [3.0.0a1]: https://github.com/sdispater/pendulum/releases/tag/3.0.0a1
 [2.1.1]: https://github.com/sdispater/pendulum/releases/tag/2.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Repository = "https://github.com/sdispater/pendulum"
 
 [tool.poetry]
 name = "pendulum"
-version = "3.0.0b1"
+version = "3.0.0"
 description = "Python datetimes made easy"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pendulum"
-version = "3.0.0b1"
+version = "3.0.0"
 description = "Python datetimes made easy"
 readme = "README.rst"
 requires-python = ">=3.8"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "_pendulum"
-version = "3.0.0-beta-1"
+version = "3.0.0"
 edition = "2021"
 
 [lib]

--- a/src/pendulum/__version__.py
+++ b/src/pendulum/__version__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
 
-__version__ = "3.0.0b1"
+__version__ = "3.0.0"


### PR DESCRIPTION
## Pull Request Check List

### Changed

- Relaxed dependency constraints. [#760](https://github.com/sdispater/pendulum/pull/760)
- The testing helpers are now  optional and must be opted-in via the `test` extra. [#778](https://github.com/sdispater/pendulum/pull/778)

### Fixed

- Removed remaining mentions of periods instead of intervals. [#757](https://github.com/sdispater/pendulum/pull/757)
- Fixed the behavior of the `week_of_month` property for edge cases in January and December. [#774](https://github.com/sdispater/pendulum/pull/774)
- Fixed the handling of the `fold` attribute when deep-copying a `DateTime` instance. [#776](https://github.com/sdispater/pendulum/pull/776)
- Fixed errors where hours and days were not handled properly when adding durations. [#775](https://github.com/sdispater/pendulum/pull/775)
- Fixed errors where hours and days were not handled properly when adding durations. [#775](https://github.com/sdispater/pendulum/pull/775)