### PR TITLE
Fix invalid email character in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Python datetimes made easy"
 readme = "README.rst"
 requires-python = ">=3.8"
 license = { text = "MIT License" }
-authors = [{ name = "Sébastien Eustace", email = "sebastien@eustace.io>" }]
+authors = [{ name = "Sébastien Eustace", email = "sebastien@eustace.io" }]
 keywords = ['datetime', 'date', 'time']
 
 classifiers = [


### PR DESCRIPTION
## Description

When updating my Pendulum recipe for my OpenEmbedded-based system, an invalid character in the email address caused setuptools to throw an error. The character can simply be removed.

## How has this been tested?

Before:

The following error occurs during build time when installing Pendulum with setuptools:

```
| ValueError: Invalid addr_spec; only 'sebastien@eustace.io' could be parsed from 'sebastien@eustace.io>'
```

After:

`import pendulum` succeeds in the installed system.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
