### PR TITLE
Fix dt warnings with timezones

### DIFF
--- a/src/pendulum/__init__.py
+++ b/src/pendulum/__init__.py
@@ -292,7 +292,7 @@ def from_timestamp(timestamp: int | float, tz: str | Timezone = UTC) -> DateTime
     """
     Create a DateTime instance from a timestamp.
     """
-    dt = _datetime.datetime.utcfromtimestamp(timestamp)
+    dt = _datetime.datetime.fromtimestamp(timestamp, tz=_datetime.UTC)
 
     dt = datetime(
         dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond

--- a/src/pendulum/datetime.py
+++ b/src/pendulum/datetime.py
@@ -1259,7 +1259,7 @@ class DateTime(datetime.datetime, Date):
 
     @classmethod
     def utcfromtimestamp(cls, t: float) -> Self:
-        return cls.instance(datetime.datetime.utcfromtimestamp(t), tz=None)
+        return cls.instance(datetime.datetime.fromtimestamp(t, datetime.UTC), tz=None)
 
     @classmethod
     def fromordinal(cls, n: int) -> Self:

--- a/tests/datetime/test_behavior.py
+++ b/tests/datetime/test_behavior.py
@@ -102,7 +102,7 @@ def test_fromtimestamp():
 
 def test_utcfromtimestamp():
     p = pendulum.DateTime.utcfromtimestamp(0)
-    dt = datetime.utcfromtimestamp(0)
+    dt = datetime.fromtimestamp(0, pendulum.UTC)
 
     assert p == dt
 


### PR DESCRIPTION
## Summary

I was about to fix another thing for myself, opened the issues list, noticed #830, and thought I'd fix it as a warm-up issue. Okay to close if this is not a good solution!

## What

This PR fixes several runtime warnings about using `utcfromtimestamp` mentioned in the issue, and that I've seen when I ran `poetry run pytest tests`. 

Did not check the boxes, not really applicable:
- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.


