### PR TITLE
Fix parsing invalid intervals

### DIFF
--- a/src/pendulum/parsing/__init__.py
+++ b/src/pendulum/parsing/__init__.py
@@ -214,11 +214,11 @@ def _parse_iso8601_interval(text: str) -> _Interval:
     first, last = text.split("/")
     start = end = duration = None
 
-    if first[0] == "P":
+    if first[0:1] == "P":
         # duration/end
         duration = parse_iso8601(first)
         end = parse_iso8601(last)
-    elif last[0] == "P":
+    elif last[0:1] == "P":
         # start/duration
         start = parse_iso8601(first)
         duration = parse_iso8601(last)

--- a/src/pendulum/parsing/__init__.py
+++ b/src/pendulum/parsing/__init__.py
@@ -214,11 +214,11 @@ def _parse_iso8601_interval(text: str) -> _Interval:
     first, last = text.split("/")
     start = end = duration = None
 
-    if first[0:1] == "P":
+    if first[:1] == "P":
         # duration/end
         duration = parse_iso8601(first)
         end = parse_iso8601(last)
-    elif last[0:1] == "P":
+    elif last[:1] == "P":
         # start/duration
         start = parse_iso8601(first)
         duration = parse_iso8601(last)

--- a/tests/parsing/test_parsing.py
+++ b/tests/parsing/test_parsing.py
@@ -660,6 +660,16 @@ def test_invalid():
     with pytest.raises(ParserError):
         parse(text)
 
+    text = "/2012"
+
+    with pytest.raises(ParserError):
+        parse(text)
+
+    text = "2012/"
+
+    with pytest.raises(ParserError):
+        parse(text)
+
 
 def test_exif_edge_case():
     text = "2016:12:26 15:45:28"


### PR DESCRIPTION
Parsing a string with a slash at the start or the end raised IndexError instead of ParseError.

## Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
