### PR TITLE
fix parse invalid interval string

### DIFF
--- a/src/pendulum/parsing/__init__.py
+++ b/src/pendulum/parsing/__init__.py
@@ -212,6 +212,10 @@ def _parse_iso8601_interval(text: str) -> _Interval:
         raise ParserError("Invalid interval")
 
     first, last = text.split("/")
+
+    if not first or not last:
+        raise ParserError("Invalid interval.")
+
     start = end = duration = None
 
     if first[0] == "P":

--- a/tests/parsing/test_parsing_duration.py
+++ b/tests/parsing/test_parsing_duration.py
@@ -293,6 +293,14 @@ def test_parse_duration_invalid():
         parse("P1Dasdfasdf")
 
 
+def test_parse_interval_invalid():
+    with pytest.raises(ParserError):
+        parse("/no_start")
+
+    with pytest.raises(ParserError):
+        parse("no_end/")
+
+
 def test_parse_duration_fraction_only_allowed_on_last_component():
     with pytest.raises(ParserError):
         parse("P2Y3M4DT5.5H6M7S")


### PR DESCRIPTION
The function `_parse_iso8601_interval` raises `IndexError` when either the `first` or the `last` part of the interval is not specified. This fix checks if the interval parts are empty strings and raises `ParserError` if so.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
