### PR TITLE
Don't eagerly load the Locale, nor pytest until it's needed.

### DIFF
--- a/src/pendulum/locales/locale.py
+++ b/src/pendulum/locales/locale.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 
-from importlib import import_module, resources
 from pathlib import Path
 from typing import Any
 from typing import ClassVar
@@ -24,6 +23,8 @@ class Locale:
 
     @classmethod
     def load(cls, locale: str | Locale) -> Locale:
+        from importlib import import_module, resources
+
         if isinstance(locale, Locale):
             return locale
 


### PR DESCRIPTION
The main problem here was that importing pendulum.testing.traveller was
importing time_machine, which was also importing pytest.

And creating the DifferenceFormatter at import time was also loading the
locale.

Both of these are "optional" in the sense that there is lots you can do in
Pendulum without ever using them, so we can relatively straightforwardly delay
things until they are requested.

Tested by running `uv run --with time_machine -p 3.12 python -Ximporttime -c 'import pendulum'`:

- Before: ~50-64ms (a lot of noise)
- After: 20-29ms

Not a huge slow down, but I figured it was worth it anyway, especially not not
load pytest.

## Pull Request Check List

<!--
This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles!
-->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
