### PR TITLE
fix: correct subtract(minutes=24) example in documentation

### DIFF
--- a/docs/docs/addition_subtraction.md
+++ b/docs/docs/addition_subtraction.md
@@ -64,7 +64,7 @@ Each method returns a new `DateTime` instance.
 >>> dt = dt.subtract(minutes=1)
 '2012-01-28 01:01:00'
 >>> dt = dt.subtract(minutes=24)
-'2012-01-28 00:00:00'
+'2012-01-28 00:37:00'
 
 >>> dt = dt.add(seconds=61)
 '2012-01-28 00:01:01'


### PR DESCRIPTION
The example incorrectly showed '2012-01-28 00:00:00' but subtracting 24 minutes from 01:01:00 should give 00:37:00.

Closes #925